### PR TITLE
chore: replace deprecated app-id with client-id and add extensions update workflow

### DIFF
--- a/.github/actions/setup-git-user/action.yml
+++ b/.github/actions/setup-git-user/action.yml
@@ -28,7 +28,7 @@ runs:
       id: app-token
       if: ${{ inputs.gh-app-id != '' }}
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.app-key }}
 
     - name: Get GitHub App User ID

--- a/.github/workflows/quarto-extensions-updates.yml
+++ b/.github/workflows/quarto-extensions-updates.yml
@@ -1,0 +1,35 @@
+name: Quarto Extensions Updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 00 12 1 * *
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  quarto-extensions-updates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Git User
+        uses: ./.github/actions/setup-git-user
+        id: setup-git-user
+        with:
+          gh-app-id: ${{ vars.APP_ID }}
+          app-key: ${{ secrets.APP_KEY }}
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Update Quarto extensions
+        uses: mcanouil/quarto-extensions-updater@v1
+        with:
+          github-token: ${{ steps.setup-git-user.outputs.token }}
+          pr-labels: "Type: Dependencies :arrow_up:"

--- a/.github/workflows/quarto-extensions-updates.yml
+++ b/.github/workflows/quarto-extensions-updates.yml
@@ -13,7 +13,7 @@ jobs:
   quarto-extensions-updates:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Replace the deprecated `app-id` input with `client-id` for `actions/create-github-app-token@v3` in the setup-git-user composite action.

Add `quarto-extensions-updates.yml` workflow using the setup-git-user composite action and `mcanouil/quarto-extensions-updater@v1` to automate monthly Quarto extension dependency updates via PR.