### PR TITLE
fix: disable fragment separation for slide thumbnail

### DIFF
--- a/.github/workflows/assets/slides-to-pdf.sh
+++ b/.github/workflows/assets/slides-to-pdf.sh
@@ -45,6 +45,7 @@ for SLIDES_PATH in ${SLIDES_FILES}; do
     --chrome-arg="--no-sandbox" \
     --chrome-arg="--disable-setuid-sandbox" \
     --size "1280x640" \
+    --no-fragments \
     --screenshots \
     --screenshots-format png \
     --screenshots-directory . \


### PR DESCRIPTION
Title slides containing fragments were captured incomplete in the thumbnail. Decktape counts each fragment as a separate page, so `--slides 1` grabbed only the first fragment state. The thumbnail decktape call now passes `--no-fragments`, folding all fragments into the final slide state so the full title slide is captured. The full PDF still exports fragments as separate pages.