### PR TITLE
feat: add the Pages workflow and split the release deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,163 @@
+# @license MIT
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
+
+name: Pages
+
+# Publishes the documentation website under docs/, which is what a repository
+# serves from GitHub Pages once it has one: it takes the slot the rendered
+# example.qmd or template.qmd used to fill. The Release workflow calls this
+# after tagging, and it is dispatchable on its own. Pull requests render the
+# site as a check, from their own head, but never deploy.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit or ref to build. Defaults to the latest version tag."
+        type: string
+        required: false
+        default: ""
+      use-main-as-release:
+        description: "Render from the triggering ref instead of the latest version tag."
+        type: boolean
+        required: false
+        default: false
+      quarto:
+        description: "Quarto version"
+        type: string
+        required: false
+        default: "release"
+  workflow_dispatch:
+    inputs:
+      use-main-as-release:
+        description: "Render from the default branch instead of the latest version tag"
+        type: boolean
+        default: false
+      quarto:
+        type: choice
+        description: "Quarto version"
+        default: "release"
+        options:
+          - "release"
+          - "pre-release"
+
+# Only the deploy job touches Pages, and it raises its own permissions.
+permissions:
+  contents: read
+
+# Pages accepts one deployment at a time, so queue rather than cancel. Pull
+# requests never deploy, so they get a per-ref group and can run in parallel.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Render site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # The whole history, so the latest version tag can be resolved below.
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      # A pull request renders its own head, so a broken page is caught before
+      # it lands. Everything else renders the released source, so the published
+      # site describes the version users can actually install.
+      - name: Resolve the ref to render
+        id: resolve-ref
+        if: ${{ inputs.ref == '' && !inputs.use-main-as-release && github.event_name != 'pull_request' }}
+        shell: bash
+        run: |
+          LATEST_TAG=$(git tag -l --sort=-v:refname '[0-9]*' | head -n 1)
+          if [ -z "${LATEST_TAG}" ]; then
+            echo "::warning::No version tags found; rendering the triggering ref instead."
+            exit 0
+          fi
+          echo "Latest tag: ${LATEST_TAG}"
+          git checkout "${LATEST_TAG}"
+
+      - name: Set up Quarto CLI
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: ${{ inputs.quarto || 'release' }}
+
+      # Quarto builds its extension registry while reading _quarto.yml, before
+      # any pre-render script runs, and it does not follow symlinks. A shortcode
+      # contributed by the repository's own extension is therefore only found
+      # when a real copy is already on disk, so the mirror is refreshed here
+      # rather than left to whatever was last committed.
+      - name: Sync the repository's extension into docs/
+        shell: bash
+        run: |
+          if [ -x "docs/_scripts/sync-extension.sh" ]; then
+            ./docs/_scripts/sync-extension.sh
+          elif [ -f "docs/_scripts/sync-extension.sh" ]; then
+            bash docs/_scripts/sync-extension.sh
+          else
+            echo "No docs/_scripts/sync-extension.sh; nothing to sync."
+          fi
+
+      - name: Render site
+        run: quarto render docs
+
+      - name: Upload site artifact
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: site
+          path: docs/_site
+          retention-days: 1
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download site artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: site
+          path: _site
+
+      - name: Prepare site for deployment
+        run: touch _site/.nojekyll
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: "./_site"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Add deployment summary
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        shell: bash
+        run: |
+          {
+            echo "## Documentation deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|--------|"
+            echo "| GitHub Pages URL | [${PAGE_URL}](${PAGE_URL}) |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/quarto-extensions-updates.yml
+++ b/.github/workflows/quarto-extensions-updates.yml
@@ -1,9 +1,28 @@
 name: Quarto Extensions Updates
 
+# Runs on a schedule for this repository, and is callable by any repository that
+# wants the same behaviour. Extension repositories call it with
+# `scan-directories: docs`, because their documentation website keeps its own
+# dependencies (atelier, iconify, gitlink) under docs/_extensions/.
 on:
   workflow_dispatch:
   schedule:
     - cron: 00 12 1 * *
+  workflow_call:
+    secrets:
+      APP_KEY:
+        description: "GitHub App private key"
+        required: false
+    inputs:
+      scan-directories:
+        description: "Newline-separated directories to scan, in addition to the repository root"
+        required: false
+        default: ""
+        type: string
+      gh-app-id:
+        description: "GitHub App ID"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
@@ -19,10 +38,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Git User
-        uses: ./.github/actions/setup-git-user
+        uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ vars.APP_ID }}
+          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
 
       - name: Setup Quarto
@@ -33,3 +52,5 @@ jobs:
         with:
           github-token: ${{ steps.setup-git-user.outputs.token }}
           pr-labels: "Type: Dependencies :arrow_up:"
+          group-updates: true
+          scan-directories: ${{ inputs.scan-directories }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       summary: ${{ steps.bump-version.outputs.summary }}
       repo_type: ${{ steps.detect-project.outputs.repo_type }}
       extension_name: ${{ steps.detect-project.outputs.extension_name }}
+      has_docs: ${{ steps.detect-project.outputs.has_docs }}
 
     steps:
       - name: Checkout repository
@@ -117,12 +118,25 @@ jobs:
               ;;
           esac
 
+          # A documentation website under docs/ takes over GitHub Pages, and the
+          # Pages workflow deploys it from the release tag. The root
+          # project is then rendered as a check only, since example.qmd and
+          # template.qmd are starting points to copy rather than pages to
+          # publish.
+          if [ -f "docs/_quarto.yml" ]; then
+            HAS_DOCS="true"
+          else
+            HAS_DOCS="false"
+          fi
+
           echo "Requested repo type: ${REQUESTED_TYPE}"
           echo "Repo type: ${REPO_TYPE}"
           echo "Extension name: ${EXTENSION}"
+          echo "Documentation website: ${HAS_DOCS}"
           {
             echo "repo_type=${REPO_TYPE}"
             echo "extension_name=${EXTENSION}"
+            echo "has_docs=${HAS_DOCS}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Bump Version
@@ -263,16 +277,16 @@ jobs:
 
     needs: bump-version
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
+    # This job renders and packages; it never deploys. A job cannot drop its
+    # `environment` conditionally, and claiming `github-pages` while deploying
+    # nothing would record a deployment that never happened, so the deployment
+    # itself lives in publish-pages (no docs/) or deploy-pages (docs/) below.
     env:
       QUARTOVERSION: ${{ inputs.quarto }}
       REPO_TYPE: ${{ needs.bump-version.outputs.repo_type }}
+      HAS_DOCS: ${{ needs.bump-version.outputs.has_docs }}
 
     outputs:
-      gh_pages_url: ${{ steps.deployment.outputs.page_url }}
       summary: ${{ steps.deployment-summary.outputs.summary }}
 
     steps:
@@ -312,12 +326,13 @@ jobs:
         id: detect-project-dir
         shell: bash
         run: |
-          if [ -f "docs/_quarto.yml" ]; then
-            PROJECT_DIR="docs"
-            echo "Using docs/ as project directory"
-          else
-            PROJECT_DIR="."
-            echo "Using root as project directory"
+          # Always the repository root. A documentation website under docs/ is
+          # rendered and deployed by the Pages workflow instead, and the
+          # root project then serves as a render check only.
+          PROJECT_DIR="."
+          echo "Using root as project directory"
+          if [ "${HAS_DOCS}" = "true" ]; then
+            echo "docs/_quarto.yml found: the root project is rendered as a check and not deployed."
           fi
 
           # Read project type and output directory from Quarto (resolves defaults)
@@ -334,10 +349,20 @@ jobs:
             fi
           fi
 
-          if [ "${PROJECT_DIR}" = "docs" ]; then
-            OUTPUT_DIRECTORY="docs/${OUTPUT_DIR}"
-          else
-            OUTPUT_DIRECTORY="${OUTPUT_DIR}"
+          OUTPUT_DIRECTORY="${OUTPUT_DIR}"
+
+          # A documentation website is a Quarto project of its own, but the root
+          # project scan does not skip a subdirectory that has one. Left alone,
+          # every page under docs/ is rendered a second time here, without the
+          # configuration, theme, and extensions that make it work, and lands in
+          # the archive attached to the release. Exclude it, so this render is
+          # the example check it claims to be.
+          if [ "${HAS_DOCS}" = "true" ]; then
+            if [ "$(yq eval '.project.render' "${PROJECT_DIR}/_quarto.yml")" = "null" ]; then
+              yq eval -i '.project.render = ["*.qmd", "!docs/"]' "${PROJECT_DIR}/_quarto.yml"
+            elif ! yq eval '.project.render[] | select(. == "!docs/")' "${PROJECT_DIR}/_quarto.yml" | grep -q 'docs/'; then
+              yq eval -i '.project.render += ["!docs/"]' "${PROJECT_DIR}/_quarto.yml"
+            fi
           fi
 
           echo "Quarto project type: ${QUARTO_PROJECT_TYPE}"
@@ -673,8 +698,16 @@ jobs:
             echo "::endgroup::"
           fi
 
-          # Package rendered output
-          tar -czf gh-pages.tar.gz -C "${OUTPUT_DIRECTORY}" .
+          # Package rendered output. With a documentation website present this
+          # is the rendered example rather than the published site, so it is
+          # named for what it actually contains.
+          if [ "${HAS_DOCS}" = "true" ]; then
+            SITE_ARCHIVE="example-render.tar.gz"
+          else
+            SITE_ARCHIVE="gh-pages.tar.gz"
+          fi
+          tar -czf "${SITE_ARCHIVE}" -C "${OUTPUT_DIRECTORY}" .
+          echo "site_archive=${SITE_ARCHIVE}" >> "${GITHUB_OUTPUT}"
 
           # Package _extensions/ if present (named as {extension}-v{version}.tar.gz and .zip)
           if [ "${REPO_TYPE}" = "extension" ] && [ -d "_extensions" ]; then
@@ -695,18 +728,20 @@ jobs:
             echo "slides_assets_exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
+      # Skipped when the repository has a documentation website: the deploy-pages
+      # job below publishes docs/ from the release tag instead, and the render
+      # above was only a check. Without one, the rendered output is staged here
+      # and publish-pages deploys it.
       - name: Configure GitHub Pages
+        if: ${{ env.HAS_DOCS != 'true' }}
         uses: actions/configure-pages@v6
 
       - name: Upload pages artifact
         id: upload-artifact
+        if: ${{ env.HAS_DOCS != 'true' }}
         uses: actions/upload-pages-artifact@v5
         with:
           path: "${{ steps.detect-project-dir.outputs.output_directory }}"
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
 
       - name: Upload release assets (slides + extensions)
         uses: actions/upload-artifact@v7
@@ -715,7 +750,7 @@ jobs:
           name: release-assets
           path: |
             ${{ steps.render-quarto.outputs.release_assets_path }}
-            gh-pages.tar.gz
+            ${{ steps.render-quarto.outputs.site_archive }}
             ${{ steps.render-quarto.outputs.extensions_asset_name }}.tar.gz
             ${{ steps.render-quarto.outputs.extensions_asset_name }}.zip
 
@@ -725,7 +760,7 @@ jobs:
         with:
           name: release-assets
           path: |
-            gh-pages.tar.gz
+            ${{ steps.render-quarto.outputs.site_archive }}
             ${{ steps.render-quarto.outputs.extensions_asset_name }}.tar.gz
             ${{ steps.render-quarto.outputs.extensions_asset_name }}.zip
 
@@ -736,7 +771,7 @@ jobs:
           name: release-assets
           path: |
             ${{ steps.render-quarto.outputs.release_assets_path }}
-            gh-pages.tar.gz
+            ${{ steps.render-quarto.outputs.site_archive }}
 
       - name: Upload release assets (default)
         uses: actions/upload-artifact@v7
@@ -744,7 +779,7 @@ jobs:
         with:
           name: release-assets
           path: |
-            gh-pages.tar.gz
+            ${{ steps.render-quarto.outputs.site_archive }}
 
       - name: Update template thumbnail
         if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
@@ -779,7 +814,6 @@ jobs:
       - name: Add deployment summary
         id: deployment-summary
         env:
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
           FORMATS: ${{ steps.inspect.outputs.formats }}
           ENGINES: ${{ steps.inspect.outputs.engines }}
         shell: bash
@@ -790,8 +824,51 @@ jobs:
           SUMMARY+="| Quarto Version | \`${QUARTOVERSION}\` |\n"
           SUMMARY+="| Output Formats | \`${FORMATS}\` |\n"
           SUMMARY+="| Engines | \`${ENGINES}\` |\n"
-          SUMMARY+="| GitHub Pages URL | [${PAGE_URL}](${PAGE_URL}) |\n"
+          if [ "${HAS_DOCS}" = "true" ]; then
+            SUMMARY+="| GitHub Pages | Deployed from \`docs/\` by the Pages workflow. |\n"
+          else
+            SUMMARY+="| GitHub Pages | Deployed by the Publish Pages job. |\n"
+          fi
           echo "summary=${SUMMARY}" >> "${GITHUB_OUTPUT}"
+
+  # A repository without docs/ publishes its rendered example or template to
+  # Pages, as it always has. The deployment sits in its own job so the
+  # github-pages environment is claimed only when something is deployed.
+  publish-pages:
+    runs-on: ubuntu-latest
+
+    needs:
+      - bump-version
+      - deploy
+
+    if: ${{ needs.bump-version.outputs.has_docs != 'true' }}
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Add deployment summary
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        shell: bash
+        run: |
+          {
+            echo "## Pages deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|--------|"
+            echo "| GitHub Pages URL | [${PAGE_URL}](${PAGE_URL}) |"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   release:
     runs-on: ubuntu-latest
@@ -877,7 +954,6 @@ jobs:
 
       - name: Display workflow summary
         env:
-          GH_PAGES_URL: ${{ needs.deploy.outputs.gh_pages_url }}
           VERSION: ${{ needs.bump-version.outputs.version }}
           BUMP_SUMMARY: ${{ needs.bump-version.outputs.summary }}
           DEPLOY_SUMMARY: ${{ needs.deploy.outputs.summary }}
@@ -901,7 +977,9 @@ jobs:
             echo ""
             echo "### Links"
             echo "- [GitHub Release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${VERSION})"
-            echo "- [Live Demo](${GH_PAGES_URL})"
+            # The Pages URL is written by whichever job deployed the site,
+            # publish-pages or the Pages workflow, both of which run beside this
+            # job rather than before it.
             echo ""
             echo "---"
             echo ""
@@ -910,3 +988,19 @@ jobs:
             echo -e "${DEPLOY_SUMMARY}"
             echo ""
           } >> "${GITHUB_STEP_SUMMARY}"
+
+  # Publishes the documentation website from the tag the release job just
+  # created, so the site describes the version users can install.
+  deploy-pages:
+    needs:
+      - bump-version
+      - release
+    if: ${{ needs.bump-version.outputs.has_docs == 'true' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: mcanouil/quarto-workflows/.github/workflows/pages.yml@main
+    with:
+      ref: ${{ needs.bump-version.outputs.version }}
+      quarto: ${{ inputs.quarto }}


### PR DESCRIPTION
## What

- **`pages.yml`** (new): renders `docs/` from the latest version tag and deploys it to GitHub Pages. Called by `release.yml` after tagging, dispatchable on its own, and run on pull requests as a render check that never deploys. A repository with a documentation website publishes that site where the rendered `example.qmd` or `template.qmd` used to go.
- **`release.yml`**: the Pages deployment moves out of the `deploy` job into a new `publish-pages` job, which runs only when there is no `docs/`. A repository with one is published by `pages.yml` from the release tag instead.
- **`release.yml`**: `docs/` is excluded from the release render when a documentation website exists.
- **`quarto-extensions-updates.yml`**: now callable, with `scan-directories` and `gh-app-id` inputs.

## Why the deployment moved

`deploy` selected its environment with an expression that resolved to an empty name when `docs/` was present. A job cannot drop `environment` conditionally, and an empty name is not a documented way to ask for none; on that path it would also have claimed a deployment that never happened, beside the real one from `pages.yml`. The job graph is now:

| Job | Runs when | Environment |
| --- | --- | --- |
| `deploy` | always | none |
| `publish-pages` | `has_docs != 'true'` | `github-pages` |
| `release` | always | none |
| `deploy-pages` calling `pages.yml` | `has_docs == 'true'` | `github-pages`, inside the reusable |

`deploy` keeps `configure-pages` and `upload-pages-artifact`, so the artifact is staged in one job and deployed in the next, as in GitHub's own Pages starter workflow. The `gh_pages_url` output is gone: each deploying job writes its own URL to the step summary, since both now run beside `release` rather than before it.

## Why `docs/` is excluded from the release render

Quarto's project scan does not skip a subdirectory holding its own `_quarto.yml`. Measured with `quarto inspect` on a copy of `mcanouil/quarto-badge`:

| | `files.input` |
| --- | --- |
| Before | `CHANGELOG.md`, `docs/examples.qmd`, `docs/reference.qmd`, `docs/404.qmd`, `docs/index.qmd`, `example.qmd` |
| After | `example.qmd` |

So every documentation page was rendered a second time, without its own configuration, theme, or extensions, and packaged into `example-render.tar.gz`. The fix appends `!docs/` to `project.render` rather than replacing an existing list, and is idempotent; both shapes were tested with `yq`.

## Verification

- `actionlint` reports only pre-existing findings: `SC2004` in the bump script, and four `required` inputs with defaults in `release-extension.yml`, which has no callers.
- The render exclusion was verified end to end on a copy of `quarto-badge`: `_site/example.html` alone.
- Callers checked across all local repositories: 46 call `release.yml`, 4 call `pages.yml`, 4 call `quarto-extensions-updates.yml`, 2 call `release-revealjs.yml`. None reference the removed output or any job name, and the reusable declares no `workflow_call` outputs.

> [!NOTE]
> The `docs/` path is exercised for the first time by `mcanouil/quarto-badge` and `mcanouil/quarto-invoice`, which are not merged yet.
