### PR TITLE
perf: derive formats from the project inspection

### DIFF
--- a/.github/actions/setup-quarto-compute/action.yml
+++ b/.github/actions/setup-quarto-compute/action.yml
@@ -50,27 +50,85 @@ runs:
         INSPECT_PATH: ${{ inputs.path }}
       shell: bash
       run: |
+        # Wherever it is set, quarto accepts `format:` as a single name or as a
+        # map of names to options, and rejects anything else.
+        KEYS_OF='def keys_of: if . == null then [] elif type == "object" then keys else [.] end;'
+
         if [ -d "${INSPECT_PATH}" ]; then
-          # Inspecting a project reports engines aggregated over every input,
-          # including .ipynb and .md, but reports no formats. Formats therefore
-          # come from a second pass over the .qmd inputs; .md files are skipped
-          # because they would contribute a spurious "html".
-          if ! PROJECT_JSON=$(quarto inspect "${INSPECT_PATH}" 2>&1); then
-            echo "::error::quarto inspect failed for '${INSPECT_PATH}'"
+          PROJECT_DIR="${INSPECT_PATH%/}"
+          if ! PROJECT_JSON=$(quarto inspect "${PROJECT_DIR}" 2>&1); then
+            echo "::error::quarto inspect failed for '${PROJECT_DIR}'"
             echo "${PROJECT_JSON}"
             exit 1
           fi
           ENGINES=$(echo "${PROJECT_JSON}" | jq -r '.engines[]?' | sort -u | xargs)
           INPUT_FILES=$(echo "${PROJECT_JSON}" | jq -r '.files.input[]?')
 
+          # Inspecting a project reports engines aggregated over every input,
+          # including .ipynb and .md, but reports no resolved formats. Rather
+          # than inspect every input in turn, which costs a quarto process per
+          # page, the formats are put back together from the three places quarto
+          # takes them from: the project config, the front matter of each input,
+          # and the _metadata.yml files above it. Only .qmd inputs are counted;
+          # .md files would contribute a spurious "html".
+          CONFIG_FORMATS=$(echo "${PROJECT_JSON}" | jq -r "${KEYS_OF}"'.config.format | keys_of | .[]' | xargs)
+
+          if [ -n "$(find "${PROJECT_DIR}" -name '_metadata.y*ml' -print -quit)" ] && ! command -v yq > /dev/null 2>&1; then
+            echo "::error::yq is required to read the _metadata.yml files under '${PROJECT_DIR}'"
+            exit 1
+          fi
+
+          # A _metadata.yml applies to the inputs beneath it, and every level
+          # from the project directory down merges rather than replaces.
+          metadata_formats() {
+            dir="${1}"
+            found=""
+            while :; do
+              for name in _metadata.yml _metadata.yaml; do
+                if [ -f "${dir}/${name}" ]; then
+                  found="${found} $(yq -o=json '.' "${dir}/${name}" | jq -r "${KEYS_OF}"'.format | keys_of | .[]' | xargs)"
+                fi
+              done
+              if [ "${dir}" = "${PROJECT_DIR}" ] || [ "${dir}" = "$(dirname "${dir}")" ]; then
+                break
+              fi
+              dir=$(dirname "${dir}")
+            done
+            printf '%s' "${found}"
+          }
+
           FILE_FORMATS=""
-          for qmd_file in $(echo "${INPUT_FILES}" | grep '\.qmd$' || true); do
-            if ! FILE_JSON=$(quarto inspect "${qmd_file}" 2>&1); then
-              echo "::warning::quarto inspect failed for '${qmd_file}'; its formats are not accounted for"
-              continue
+          USES_CONFIG_FORMATS=false
+          while IFS=$'\t' read -r rel front_matter_formats; do
+            [ -n "${rel}" ] || continue
+            rel_dir=$(dirname "${rel}")
+            if [ "${rel_dir}" = "." ]; then
+              file_dir="${PROJECT_DIR}"
+            else
+              file_dir="${PROJECT_DIR}/${rel_dir}"
             fi
-            FILE_FORMATS="${FILE_FORMATS} $(echo "${FILE_JSON}" | jq -r '.formats // {} | keys[]' | xargs)"
-          done
+            directory_formats=$(metadata_formats "${file_dir}")
+            file_formats=$(echo "${directory_formats} ${front_matter_formats}" | xargs)
+            # Front matter and _metadata.yml both replace the project config, so
+            # an input only renders the config formats when it sets none itself.
+            if [ -z "${file_formats}" ]; then
+              USES_CONFIG_FORMATS=true
+            fi
+            FILE_FORMATS="${FILE_FORMATS} ${file_formats}"
+          done < <(echo "${PROJECT_JSON}" | jq -r "${KEYS_OF}"'
+            .dir as $dir
+            | (.fileInformation // {}) as $files
+            | .files.input[]?
+            | select(endswith(".qmd"))
+            | ltrimstr($dir + "/") as $rel
+            | [$rel, ($files[$rel].metadata.format | keys_of | join(" "))]
+            | @tsv')
+
+          # An input that sets no format of its own renders the config formats,
+          # and plain html when the config sets none either.
+          if [ "${USES_CONFIG_FORMATS}" = "true" ]; then
+            FILE_FORMATS="${FILE_FORMATS} ${CONFIG_FORMATS:-html}"
+          fi
           FORMATS=$(echo "${FILE_FORMATS}" | tr ' ' '\n' | sed '/^$/d' | sort -u | xargs)
         else
           if ! FILE_JSON=$(quarto inspect "${INSPECT_PATH}" 2>&1); then

--- a/.github/workflows/test-setup-quarto-compute.yml
+++ b/.github/workflows/test-setup-quarto-compute.yml
@@ -46,6 +46,8 @@ jobs:
             expect-python: "false"
             expect-julia: "false"
             expect-tinytex: "false"
+            expect-formats: html
+            expect-inputs: index.qmd
             verify: Rscript -e 'stopifnot(requireNamespace("jsonlite", quietly = TRUE))'
             verify-directory: tests/knitr-renv
             render: "false"
@@ -54,6 +56,8 @@ jobs:
             expect-python: "true"
             expect-julia: "false"
             expect-tinytex: "false"
+            expect-formats: html
+            expect-inputs: index.qmd
             verify: jupyter --version
             render: "true"
           - fixture: jupyter-uv
@@ -61,6 +65,8 @@ jobs:
             expect-python: "true"
             expect-julia: "false"
             expect-tinytex: "false"
+            expect-formats: html
+            expect-inputs: index.qmd
             verify: jupyter --version
             render: "true"
           - fixture: julia
@@ -68,6 +74,8 @@ jobs:
             expect-python: "false"
             expect-julia: "true"
             expect-tinytex: "false"
+            expect-formats: html
+            expect-inputs: index.qmd
             # IJulia is added to the project the action instantiated, which is
             # the workspace when the fixture carries no Project.toml.
             verify: julia --project=. -e 'using IJulia'
@@ -77,6 +85,8 @@ jobs:
             expect-python: "false"
             expect-julia: "false"
             expect-tinytex: "true"
+            expect-formats: pdf
+            expect-inputs: index.qmd
             verify: pdflatex --version
             render: "true"
           - fixture: revealjs
@@ -84,6 +94,21 @@ jobs:
             expect-python: "false"
             expect-julia: "false"
             expect-tinytex: "false"
+            expect-formats: revealjs
+            expect-inputs: index.qmd
+            verify: quarto --version
+            render: "true"
+          # Formats are derived from the project JSON rather than from a pass
+          # over every input, so this fixture sets them in each of the places
+          # quarto reads them from: the project config, the front matter of an
+          # input, and a _metadata.yml nested inside another one.
+          - fixture: formats
+            expect-r: "false"
+            expect-python: "false"
+            expect-julia: "false"
+            expect-tinytex: "false"
+            expect-formats: docx gfm html revealjs typst
+            expect-inputs: index.qmd slides.qmd sub/deep/deep.qmd sub/page.qmd
             verify: quarto --version
             render: "true"
 
@@ -108,10 +133,13 @@ jobs:
           NEED_PYTHON: ${{ steps.compute.outputs.need-python }}
           NEED_JULIA: ${{ steps.compute.outputs.need-julia }}
           NEED_TINYTEX: ${{ steps.compute.outputs.need-tinytex }}
+          FORMATS: ${{ steps.compute.outputs.formats }}
           EXPECT_R: ${{ matrix.expect-r }}
           EXPECT_PYTHON: ${{ matrix.expect-python }}
           EXPECT_JULIA: ${{ matrix.expect-julia }}
           EXPECT_TINYTEX: ${{ matrix.expect-tinytex }}
+          EXPECT_FORMATS: ${{ matrix.expect-formats }}
+          EXPECT_INPUTS: ${{ matrix.expect-inputs }}
           INPUT_FILES: ${{ steps.compute.outputs.input-files }}
           FIXTURE: ${{ matrix.fixture }}
         shell: bash
@@ -124,11 +152,18 @@ jobs:
             fi
           }
 
+          # The action reports the inputs in whatever order quarto lists them.
+          EXPECTED_INPUTS=""
+          for input in ${EXPECT_INPUTS}; do
+            EXPECTED_INPUTS="${EXPECTED_INPUTS}${GITHUB_WORKSPACE}/tests/${FIXTURE}/${input}"$'\n'
+          done
+
           assert_eq need-r "${NEED_R}" "${EXPECT_R}"
           assert_eq need-python "${NEED_PYTHON}" "${EXPECT_PYTHON}"
           assert_eq need-julia "${NEED_JULIA}" "${EXPECT_JULIA}"
           assert_eq need-tinytex "${NEED_TINYTEX}" "${EXPECT_TINYTEX}"
-          assert_eq input-files "${INPUT_FILES}" "${GITHUB_WORKSPACE}/tests/${FIXTURE}/index.qmd"
+          assert_eq formats "${FORMATS}" "${EXPECT_FORMATS}"
+          assert_eq input-files "$(echo "${INPUT_FILES}" | sort)" "$(printf '%s' "${EXPECTED_INPUTS}" | sort)"
 
           if [ "${FAILED}" = "true" ]; then
             exit 1

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ A composite action that reads what a Quarto project needs from `quarto inspect`,
 It is used by both `release.yml` and `pages.yml`, and expects Quarto to be installed already, along with any extension the project resolves.
 
 Engines come from the project-level inspection, so `.qmd`, `.ipynb`, and `.md` inputs all count.
-Formats come from a second pass over the `.qmd` inputs, since a project inspection reports none.
+Formats are derived from that same inspection rather than from a pass over every input, since a project inspection reports engines but no resolved formats.
+They are collected from the project configuration, the front matter of each `.qmd` input, and the `_metadata.yml` files above it, which is where Quarto itself reads them from.
+Reading those `_metadata.yml` files needs `yq`, which the GitHub-hosted runners provide.
 Dependency manifests are looked up in the project directory first and the repository root second, which is how a `docs/` website renders with a `pyproject.toml` or `renv.lock` kept at the root.
 
 A Python environment is left activated by `uv`, so later steps render with it without sourcing anything.

--- a/tests/formats/_quarto.yml
+++ b/tests/formats/_quarto.yml
@@ -1,0 +1,5 @@
+project:
+  output-dir: _site
+format:
+  html: default
+  docx: default

--- a/tests/formats/index.qmd
+++ b/tests/formats/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "Project formats"
+---
+
+Renders the formats the project config sets.

--- a/tests/formats/slides.qmd
+++ b/tests/formats/slides.qmd
@@ -1,0 +1,7 @@
+---
+title: "Front matter formats"
+format:
+  revealjs: default
+---
+
+Front matter replaces the formats the project config sets.

--- a/tests/formats/sub/_metadata.yml
+++ b/tests/formats/sub/_metadata.yml
@@ -1,0 +1,2 @@
+format:
+  typst: default

--- a/tests/formats/sub/deep/_metadata.yml
+++ b/tests/formats/sub/deep/_metadata.yml
@@ -1,0 +1,2 @@
+format:
+  gfm: default

--- a/tests/formats/sub/deep/deep.qmd
+++ b/tests/formats/sub/deep/deep.qmd
@@ -1,0 +1,5 @@
+---
+title: "Nested directory formats"
+---
+
+A nested _metadata.yml merges with the one above it.

--- a/tests/formats/sub/page.qmd
+++ b/tests/formats/sub/page.qmd
@@ -1,0 +1,5 @@
+---
+title: "Directory formats"
+---
+
+A _metadata.yml replaces the formats the project config sets.


### PR DESCRIPTION
Collecting formats used to inspect every `.qmd` input in turn, one quarto process per page, because a project inspection reports engines but no resolved formats. They are now put back together from the project JSON and the `_metadata.yml` files it does not report: the project config, the front matter of each input, and every `_metadata.yml` above it, which is where quarto reads them from. Reading those files needs `yq`, which the GitHub-hosted runners provide, and the action fails with a clear message when a project has one and `yq` is missing.

Front matter and a `_metadata.yml` both replace the project config, while `_metadata.yml` files merge with each other and with the front matter, so an input falls back to the config formats, or to plain `html`, only when it sets none of its own.

A `formats` fixture sets formats in each of those places, and the detection tests now assert the formats and the input files every fixture reports, not just the engines. Locally the fixture goes from five quarto processes to one, 5.6s to 1.2s for four pages, and every fixture derives the same formats the loop reported.