### PR TITLE
fix: keep quarto's log out of the detection JSON

### DIFF
--- a/.github/actions/setup-quarto-compute/action.yml
+++ b/.github/actions/setup-quarto-compute/action.yml
@@ -54,15 +54,35 @@ runs:
         # map of names to options, and rejects anything else.
         KEYS_OF='def keys_of: if . == null then [] elif type == "object" then keys else [.] end;'
 
+        INSPECT_JSON=$(mktemp)
+        INSPECT_LOG=$(mktemp)
+        INSPECT_ERR=$(mktemp)
+        trap 'rm -f "${INSPECT_JSON}" "${INSPECT_LOG}" "${INSPECT_ERR}"' EXIT
+
+        # quarto writes its log to stderr, and a runner with step debug logging
+        # on turns that log up to DEBUG, which puts a version banner in front of
+        # everything quarto prints. The log therefore goes to a file and stdout
+        # is read on its own, so only the JSON ever reaches jq. The log and
+        # anything that bypassed it are reported when the command fails.
+        inspect() {
+          if ! quarto inspect "${1}" --quiet --log "${INSPECT_LOG}" \
+            > "${INSPECT_JSON}" 2> "${INSPECT_ERR}"; then
+            echo "::error::quarto inspect failed for '${1}'"
+            cat "${INSPECT_LOG}" "${INSPECT_ERR}" >&2
+            return 1
+          fi
+          if ! jq -e 'type == "object"' "${INSPECT_JSON}" > /dev/null 2>&1; then
+            echo "::error::quarto inspect for '${1}' did not produce JSON"
+            cat "${INSPECT_JSON}" "${INSPECT_LOG}" "${INSPECT_ERR}" >&2
+            return 1
+          fi
+        }
+
         if [ -d "${INSPECT_PATH}" ]; then
           PROJECT_DIR="${INSPECT_PATH%/}"
-          if ! PROJECT_JSON=$(quarto inspect "${PROJECT_DIR}" 2>&1); then
-            echo "::error::quarto inspect failed for '${PROJECT_DIR}'"
-            echo "${PROJECT_JSON}"
-            exit 1
-          fi
-          ENGINES=$(echo "${PROJECT_JSON}" | jq -r '.engines[]?' | sort -u | xargs)
-          INPUT_FILES=$(echo "${PROJECT_JSON}" | jq -r '.files.input[]?')
+          inspect "${PROJECT_DIR}" || exit 1
+          ENGINES=$(jq -r '.engines[]?' "${INSPECT_JSON}" | sort -u | xargs)
+          INPUT_FILES=$(jq -r '.files.input[]?' "${INSPECT_JSON}")
 
           # Inspecting a project reports engines aggregated over every input,
           # including .ipynb and .md, but reports no resolved formats. Rather
@@ -71,7 +91,7 @@ runs:
           # takes them from: the project config, the front matter of each input,
           # and the _metadata.yml files above it. Only .qmd inputs are counted;
           # .md files would contribute a spurious "html".
-          CONFIG_FORMATS=$(echo "${PROJECT_JSON}" | jq -r "${KEYS_OF}"'.config.format | keys_of | .[]' | xargs)
+          CONFIG_FORMATS=$(jq -r "${KEYS_OF}"'.config.format | keys_of | .[]' "${INSPECT_JSON}" | xargs)
 
           if [ -n "$(find "${PROJECT_DIR}" -name '_metadata.y*ml' -print -quit)" ] && ! command -v yq > /dev/null 2>&1; then
             echo "::error::yq is required to read the _metadata.yml files under '${PROJECT_DIR}'"
@@ -115,14 +135,14 @@ runs:
               USES_CONFIG_FORMATS=true
             fi
             FILE_FORMATS="${FILE_FORMATS} ${file_formats}"
-          done < <(echo "${PROJECT_JSON}" | jq -r "${KEYS_OF}"'
+          done < <(jq -r "${KEYS_OF}"'
             .dir as $dir
             | (.fileInformation // {}) as $files
             | .files.input[]?
             | select(endswith(".qmd"))
             | ltrimstr($dir + "/") as $rel
             | [$rel, ($files[$rel].metadata.format | keys_of | join(" "))]
-            | @tsv')
+            | @tsv' "${INSPECT_JSON}")
 
           # An input that sets no format of its own renders the config formats,
           # and plain html when the config sets none either.
@@ -131,13 +151,9 @@ runs:
           fi
           FORMATS=$(echo "${FILE_FORMATS}" | tr ' ' '\n' | sed '/^$/d' | sort -u | xargs)
         else
-          if ! FILE_JSON=$(quarto inspect "${INSPECT_PATH}" 2>&1); then
-            echo "::error::quarto inspect failed for '${INSPECT_PATH}'"
-            echo "${FILE_JSON}"
-            exit 1
-          fi
-          ENGINES=$(echo "${FILE_JSON}" | jq -r '.engines[]?' | sort -u | xargs)
-          FORMATS=$(echo "${FILE_JSON}" | jq -r '.formats // {} | keys[]' | sort -u | xargs)
+          inspect "${INSPECT_PATH}" || exit 1
+          ENGINES=$(jq -r '.engines[]?' "${INSPECT_JSON}" | sort -u | xargs)
+          FORMATS=$(jq -r '.formats // {} | keys[]' "${INSPECT_JSON}" | sort -u | xargs)
           INPUT_FILES="${INSPECT_PATH}"
         fi
 

--- a/.github/workflows/test-setup-quarto-compute.yml
+++ b/.github/workflows/test-setup-quarto-compute.yml
@@ -27,8 +27,14 @@ concurrency:
 
 jobs:
   detect:
-    name: ${{ matrix.fixture }}
+    name: ${{ matrix.label || matrix.fixture }}
     runs-on: ubuntu-latest
+
+    # Set for the job rather than for the compute step, so it reaches the steps
+    # the composite action runs. Every fixture but one leaves it empty, and
+    # quarto only treats the exact string "1" as debug logging.
+    env:
+      RUNNER_DEBUG: ${{ matrix.runner-debug }}
 
     strategy:
       fail-fast: false
@@ -111,6 +117,21 @@ jobs:
             expect-inputs: index.qmd slides.qmd sub/deep/deep.qmd sub/page.qmd
             verify: quarto --version
             render: "true"
+          # A runner with step debug logging on exports RUNNER_DEBUG=1, which
+          # turns quarto's log up to DEBUG and puts a version banner on stderr
+          # ahead of everything else it prints. Detection has to read the JSON
+          # alone, so the richest fixture is detected a second time under it.
+          - fixture: formats
+            label: formats (debug logging)
+            runner-debug: "1"
+            expect-r: "false"
+            expect-python: "false"
+            expect-julia: "false"
+            expect-tinytex: "false"
+            expect-formats: docx gfm html revealjs typst
+            expect-inputs: index.qmd slides.qmd sub/deep/deep.qmd sub/page.qmd
+            verify: quarto --version
+            render: "false"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The compute action captured `quarto inspect` with `2>&1`, so anything quarto wrote to stderr became part of the JSON it handed to `jq`. On a runner with step debug logging enabled, `RUNNER_DEBUG=1` makes quarto log at `DEBUG`, and the first record it writes is `Quarto version: 1.10.18`. `quarto inspect` still exited 0, so the error branch never ran and the step failed with `jq: parse error: Invalid numeric literal at line 1, column 7` and exit code 5, as it did for the Pages run on mcanouil/quarto-mcanouil#118.

Detection now runs `quarto inspect --quiet --log <file>`, reads stdout on its own, and prints the log file and anything left on stderr when the command fails, so a genuine failure still explains itself. `--log` alone does not help, since it adds a file handler and leaves the console handler writing to stderr. Every jq read now takes the JSON file as an argument rather than piping a variable, which also removes the pipelines whose `pipefail` status produced the opaque exit code. A second guard reports a named error if stdout is ever not JSON.

The test workflow detects the formats fixture a second time with `RUNNER_DEBUG=1`, which fails on the current code and passes here.