### PR TITLE
fix: make GitHub App credentials genuinely optional

### DIFF
--- a/.github/actions/setup-git-user/action.yml
+++ b/.github/actions/setup-git-user/action.yml
@@ -23,10 +23,36 @@ outputs:
 runs:
   using: composite
   steps:
+    # A GitHub App is optional, and half of one is not usable: create-github-app-token
+    # declares private-key as required, so a caller carrying the App id in a
+    # repository variable but no key would fail here rather than fall back.
+    # Deciding the path up front keeps a missing key a warning.
+    - name: Resolve the credentials to use
+      id: credentials
+      env:
+        APP_ID: ${{ inputs.gh-app-id }}
+        APP_KEY: ${{ inputs.app-key }}
+        FALLBACK_TOKEN: ${{ inputs.gh-token }}
+      shell: bash
+      run: |
+        USE_APP=false
+        if [ -n "${APP_ID}" ] && [ -n "${APP_KEY}" ]; then
+          USE_APP=true
+        elif [ -n "${APP_ID}" ]; then
+          echo "::warning::gh-app-id was provided without app-key; falling back to gh-token and the github-actions[bot] identity."
+        fi
+
+        if [ "${USE_APP}" = "false" ] && [ -z "${FALLBACK_TOKEN}" ]; then
+          echo "::error::No credentials were provided: pass gh-app-id together with app-key, or pass gh-token."
+          exit 1
+        fi
+
+        echo "use-app=${USE_APP}" >> "${GITHUB_OUTPUT}"
+
     - name: Create GitHub App token
       uses: actions/create-github-app-token@v3
       id: app-token
-      if: ${{ inputs.gh-app-id != '' }}
+      if: ${{ steps.credentials.outputs.use-app == 'true' }}
       with:
         client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.app-key }}
@@ -47,7 +73,14 @@ runs:
         USER_ID: ${{ steps.get-user-id.outputs.user-id }}
       shell: bash
       run: |
-        if [ -z "${APP_SLUG}" ]; then
+        # The App identity needs the numeric user id to form the noreply address,
+        # so a lookup that came back empty falls back rather than committing as
+        # the malformed "+slug[bot]@users.noreply.github.com".
+        if [ -n "${APP_SLUG}" ] && [ -z "${USER_ID}" ]; then
+          echo "::warning::Could not resolve the user id for ${APP_SLUG}[bot]; using the github-actions[bot] identity."
+        fi
+
+        if [ -z "${APP_SLUG}" ] || [ -z "${USER_ID}" ]; then
           USER_NAME="github-actions[bot]"
           USER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
         else
@@ -56,3 +89,4 @@ runs:
         fi
         git config --global user.name "${USER_NAME}"
         git config --global user.email "${USER_EMAIL}"
+        echo "Git identity: ${USER_NAME} <${USER_EMAIL}>"

--- a/.github/workflows/assets/assert-git-identity.sh
+++ b/.github/workflows/assets/assert-git-identity.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Asserts the git identity setup-git-user wrote, for one of the credential paths
+# it resolves. TOKEN carries the token the action returned.
+
+set -euo pipefail
+
+MODE="${1:?usage: assert-git-identity.sh <fallback|app>}"
+TOKEN="${TOKEN:-}"
+
+FALLBACK_NAME="github-actions[bot]"
+FALLBACK_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+
+# An unset key exits non-zero, which would abort before reporting which
+# assertion failed.
+NAME=$(git config --global user.name || true)
+EMAIL=$(git config --global user.email || true)
+
+FAILED=false
+fail() {
+  echo "::error::${1}"
+  FAILED=true
+}
+
+if [ -z "${TOKEN}" ]; then
+  fail "The action resolved no token."
+fi
+
+case "${MODE}" in
+  fallback)
+    [ "${NAME}" = "${FALLBACK_NAME}" ] || fail "user.name: expected '${FALLBACK_NAME}', got '${NAME}'"
+    [ "${EMAIL}" = "${FALLBACK_EMAIL}" ] || fail "user.email: expected '${FALLBACK_EMAIL}', got '${EMAIL}'"
+    ;;
+  app)
+    # The App slug is whatever App the repository configured, so the shape of the
+    # identity is asserted rather than a particular name.
+    if [ "${NAME}" = "${FALLBACK_NAME}" ] || [ "${NAME}" = "${NAME%\[bot\]}" ]; then
+      fail "user.name: expected an App bot, got '${NAME}'"
+    fi
+    echo "${EMAIL}" | grep -qE '^[0-9]+\+.+\[bot\]@users\.noreply\.github\.com$' ||
+      fail "user.email: expected a numeric App noreply address, got '${EMAIL}'"
+    ;;
+  *)
+    echo "::error::Unknown mode '${MODE}' (expected fallback or app)"
+    exit 1
+    ;;
+esac
+
+if [ "${FAILED}" = "true" ]; then
+  exit 1
+fi
+echo "The ${MODE} identity is ${NAME} <${EMAIL}>."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ permissions:
   id-token: write
   pages: write
 
+# Every job resolves its own token, and each has to be told the same App id, so
+# it is derived once here rather than in each of the four calls. The key and the
+# fallback token stay at the call sites, since a workflow-level `env` cannot
+# read `secrets`.
+env:
+  APP_ID: ${{ inputs.gh-app-id || vars.APP_ID }}
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
@@ -64,7 +71,7 @@ jobs:
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
+          gh-app-id: ${{ env.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -301,7 +308,7 @@ jobs:
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
+          gh-app-id: ${{ env.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -627,7 +634,7 @@ jobs:
         if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         with:
-          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
+          gh-app-id: ${{ env.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -735,7 +742,7 @@ jobs:
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
+          gh-app-id: ${{ env.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,16 +55,23 @@ jobs:
       has_docs: ${{ steps.detect-project.outputs.has_docs }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
+      # Before the checkout, so the branch this job pushes carries the resolved
+      # identity. The action needs no working tree of its own. A push made with
+      # the default GITHUB_TOKEN triggers no workflow, which leaves the version
+      # bump pull request without the checks its auto-merge waits for, so a
+      # repository with a GitHub App pushes as the App instead.
       - name: Setup Git User
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id }}
+          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.setup-git-user.outputs.token }}
 
       - name: Detect project type
         id: detect-project
@@ -290,16 +297,18 @@ jobs:
       summary: ${{ steps.deployment-summary.outputs.summary }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
       - name: Setup Git User
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id }}
+          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.setup-git-user.outputs.token }}
 
       - name: Update branch
         run: |
@@ -610,16 +619,34 @@ jobs:
           path: |
             ${{ steps.render-quarto.outputs.site_archive }}
 
+      # A GitHub App token lasts an hour, and this job spends that hour
+      # installing runtimes and rendering before it pushes anything, so the one
+      # the checkout is holding may well have expired by now.
+      - name: Refresh the token before pushing
+        id: refresh-git-user
+        if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
+        uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
+        with:
+          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
+          app-key: ${{ secrets.APP_KEY }}
+          gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
       - name: Update template thumbnail
         if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.setup-git-user.outputs.token }}
+          GH_TOKEN: ${{ steps.refresh-git-user.outputs.token }}
           OUTPUT_DIRECTORY: ${{ steps.detect-project-dir.outputs.output_directory }}
           BRANCH: ci/update-thumbs
           COMMIT: "ci: update thumbs :art:"
         shell: bash
         run: |
           if [ -f "${OUTPUT_DIRECTORY}/index.png" ]; then
+            # actions/checkout left the token it was given in an http extraheader,
+            # which wins over anything in the remote URL, so the stale one has to
+            # go before the fresh one can be used.
+            git config --local --unset-all "http.https://github.com/.extraheader" || true
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
             mv -f "${OUTPUT_DIRECTORY}/index.png" .github/template.png
             if git show-ref --quiet "refs/heads/${BRANCH}"; then
               echo "Branch ${BRANCH} already exists."
@@ -704,16 +731,18 @@ jobs:
       - deploy
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
       - name: Setup Git User
         uses: mcanouil/quarto-workflows/.github/actions/setup-git-user@main
         id: setup-git-user
         with:
-          gh-app-id: ${{ inputs.gh-app-id }}
+          gh-app-id: ${{ inputs.gh-app-id || vars.APP_ID }}
           app-key: ${{ secrets.APP_KEY }}
           gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.setup-git-user.outputs.token }}
 
       - name: Update branch
         run: |

--- a/.github/workflows/test-setup-git-user.yml
+++ b/.github/workflows/test-setup-git-user.yml
@@ -86,8 +86,10 @@ jobs:
         shell: bash
         run: |
           FAILED=false
-          NAME=$(git config --global user.name)
-          EMAIL=$(git config --global user.email)
+          # An unset key exits non-zero, which would abort the step before it
+          # could report which assertion failed.
+          NAME=$(git config --global user.name || true)
+          EMAIL=$(git config --global user.email || true)
 
           if [ -z "${TOKEN}" ]; then
             echo "::error::The action resolved no token."
@@ -132,8 +134,10 @@ jobs:
         shell: bash
         run: |
           FAILED=false
-          NAME=$(git config --global user.name)
-          EMAIL=$(git config --global user.email)
+          # An unset key exits non-zero, which would abort the step before it
+          # could report which assertion failed.
+          NAME=$(git config --global user.name || true)
+          EMAIL=$(git config --global user.email || true)
 
           if [ -z "${TOKEN}" ]; then
             echo "::error::The action resolved no token."

--- a/.github/workflows/test-setup-git-user.yml
+++ b/.github/workflows/test-setup-git-user.yml
@@ -1,0 +1,180 @@
+# @license MIT
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
+
+name: Test Setup Git User
+
+# A GitHub App is optional, so the action has to resolve an identity and a token
+# whether or not one is configured, and say so rather than fail when only half
+# of a GitHub App is available. Each of those paths is exercised here.
+on:
+  pull_request:
+    paths:
+      - ".github/actions/setup-git-user/**"
+      - ".github/workflows/test-setup-git-user.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "30 5 1 * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FALLBACK_NAME: github-actions[bot]
+  FALLBACK_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+jobs:
+  # A job-level `if` cannot read `secrets`, and a pull request from a fork sees
+  # none, so whether the GitHub App path can run at all is decided here.
+  check-app:
+    name: Check for App credentials
+    runs-on: ubuntu-latest
+
+    outputs:
+      has-app: ${{ steps.check.outputs.has-app }}
+
+    steps:
+      - name: Check for App credentials
+        id: check
+        env:
+          APP_ID: ${{ vars.APP_ID }}
+          APP_KEY: ${{ secrets.APP_KEY }}
+        shell: bash
+        run: |
+          if [ -n "${APP_ID}" ] && [ -n "${APP_KEY}" ]; then
+            HAS_APP=true
+          else
+            HAS_APP=false
+            echo "No App credentials available; the App path is skipped."
+          fi
+          echo "has-app=${HAS_APP}" >> "${GITHUB_OUTPUT}"
+
+  fallback:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: No App credentials
+            gh-app-id: ""
+          # The regression guard for a repository that carries the App id in a
+          # variable but has no key: the action warns and falls back rather than
+          # failing on the key create-github-app-token requires.
+          - label: App id without a key
+            gh-app-id: "Iv1.0000000000000000"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Git User
+        id: setup-git-user
+        uses: ./.github/actions/setup-git-user
+        with:
+          gh-app-id: ${{ matrix.gh-app-id }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert the fallback identity
+        env:
+          TOKEN: ${{ steps.setup-git-user.outputs.token }}
+        shell: bash
+        run: |
+          FAILED=false
+          NAME=$(git config --global user.name)
+          EMAIL=$(git config --global user.email)
+
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::The action resolved no token."
+            FAILED=true
+          fi
+          if [ "${NAME}" != "${FALLBACK_NAME}" ]; then
+            echo "::error::user.name: expected '${FALLBACK_NAME}', got '${NAME}'"
+            FAILED=true
+          fi
+          if [ "${EMAIL}" != "${FALLBACK_EMAIL}" ]; then
+            echo "::error::user.email: expected '${FALLBACK_EMAIL}', got '${EMAIL}'"
+            FAILED=true
+          fi
+
+          if [ "${FAILED}" = "true" ]; then
+            exit 1
+          fi
+          echo "The fallback identity is ${NAME} <${EMAIL}>."
+
+  app:
+    name: App credentials
+    runs-on: ubuntu-latest
+
+    needs: check-app
+    if: ${{ needs.check-app.outputs.has-app == 'true' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Git User
+        id: setup-git-user
+        uses: ./.github/actions/setup-git-user
+        with:
+          gh-app-id: ${{ vars.APP_ID }}
+          app-key: ${{ secrets.APP_KEY }}
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert the App identity
+        env:
+          TOKEN: ${{ steps.setup-git-user.outputs.token }}
+        shell: bash
+        run: |
+          FAILED=false
+          NAME=$(git config --global user.name)
+          EMAIL=$(git config --global user.email)
+
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::The action resolved no token."
+            FAILED=true
+          fi
+          # The App slug is whatever App the repository configured, so the shape
+          # of the identity is asserted rather than a particular name.
+          if [ "${NAME}" = "${FALLBACK_NAME}" ] || [ "${NAME}" = "${NAME%\[bot\]}" ]; then
+            echo "::error::user.name: expected an App bot, got '${NAME}'"
+            FAILED=true
+          fi
+          if ! echo "${EMAIL}" | grep -qE '^[0-9]+\+.+\[bot\]@users\.noreply\.github\.com$'; then
+            echo "::error::user.email: expected a numeric App noreply address, got '${EMAIL}'"
+            FAILED=true
+          fi
+
+          if [ "${FAILED}" = "true" ]; then
+            exit 1
+          fi
+          echo "The App identity is ${NAME} <${EMAIL}>."
+
+  no-credentials:
+    name: No credentials at all
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Git User
+        id: setup-git-user
+        continue-on-error: true
+        uses: ./.github/actions/setup-git-user
+
+      - name: Assert the action failed
+        env:
+          OUTCOME: ${{ steps.setup-git-user.outcome }}
+        shell: bash
+        run: |
+          if [ "${OUTCOME}" != "failure" ]; then
+            echo "::error::Expected the action to fail without credentials, got '${OUTCOME}'"
+            exit 1
+          fi
+          echo "The action refused to run without credentials."

--- a/.github/workflows/test-setup-git-user.yml
+++ b/.github/workflows/test-setup-git-user.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - ".github/actions/setup-git-user/**"
       - ".github/workflows/test-setup-git-user.yml"
+      - ".github/workflows/assets/assert-git-identity.sh"
   workflow_dispatch:
   schedule:
     - cron: "30 5 1 * *"
@@ -22,10 +23,6 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-env:
-  FALLBACK_NAME: github-actions[bot]
-  FALLBACK_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 jobs:
   # A job-level `if` cannot read `secrets`, and a pull request from a fork sees
@@ -84,30 +81,7 @@ jobs:
         env:
           TOKEN: ${{ steps.setup-git-user.outputs.token }}
         shell: bash
-        run: |
-          FAILED=false
-          # An unset key exits non-zero, which would abort the step before it
-          # could report which assertion failed.
-          NAME=$(git config --global user.name || true)
-          EMAIL=$(git config --global user.email || true)
-
-          if [ -z "${TOKEN}" ]; then
-            echo "::error::The action resolved no token."
-            FAILED=true
-          fi
-          if [ "${NAME}" != "${FALLBACK_NAME}" ]; then
-            echo "::error::user.name: expected '${FALLBACK_NAME}', got '${NAME}'"
-            FAILED=true
-          fi
-          if [ "${EMAIL}" != "${FALLBACK_EMAIL}" ]; then
-            echo "::error::user.email: expected '${FALLBACK_EMAIL}', got '${EMAIL}'"
-            FAILED=true
-          fi
-
-          if [ "${FAILED}" = "true" ]; then
-            exit 1
-          fi
-          echo "The fallback identity is ${NAME} <${EMAIL}>."
+        run: .github/workflows/assets/assert-git-identity.sh fallback
 
   app:
     name: App credentials
@@ -132,32 +106,7 @@ jobs:
         env:
           TOKEN: ${{ steps.setup-git-user.outputs.token }}
         shell: bash
-        run: |
-          FAILED=false
-          # An unset key exits non-zero, which would abort the step before it
-          # could report which assertion failed.
-          NAME=$(git config --global user.name || true)
-          EMAIL=$(git config --global user.email || true)
-
-          if [ -z "${TOKEN}" ]; then
-            echo "::error::The action resolved no token."
-            FAILED=true
-          fi
-          # The App slug is whatever App the repository configured, so the shape
-          # of the identity is asserted rather than a particular name.
-          if [ "${NAME}" = "${FALLBACK_NAME}" ] || [ "${NAME}" = "${NAME%\[bot\]}" ]; then
-            echo "::error::user.name: expected an App bot, got '${NAME}'"
-            FAILED=true
-          fi
-          if ! echo "${EMAIL}" | grep -qE '^[0-9]+\+.+\[bot\]@users\.noreply\.github\.com$'; then
-            echo "::error::user.email: expected a numeric App noreply address, got '${EMAIL}'"
-            FAILED=true
-          fi
-
-          if [ "${FAILED}" = "true" ]; then
-            exit 1
-          fi
-          echo "The App identity is ${NAME} <${EMAIL}>."
+        run: .github/workflows/assets/assert-git-identity.sh app
 
   no-credentials:
     name: No credentials at all

--- a/README.md
+++ b/README.md
@@ -30,19 +30,26 @@ Key features include:
 | `version`   | `"minor"`   | Version bump type (`patch`/`minor`/`major`). Used for extensions only; ignored for projects.        |
 | `repo-type` | `"auto"`    | Repo type (`auto`/`extension`/`project`). `auto` detects from the repo name and owned manifest.     |
 | `quarto`    | `"release"` | Quarto version to install (`release` or `pre-release`).                                             |
-| `gh-app-id` |             | GitHub App ID for authentication (optional).                                                        |
+| `gh-app-id` |             | GitHub App ID for authentication (optional). Falls back to the `APP_ID` repository variable.        |
 
-#### Secrets
+#### Authentication
 
-The workflow accepts secrets via `secrets: inherit`.
-When a GitHub App is used for authentication (recommended), the following secrets should be configured in the calling repository:
+A GitHub App is optional.
+The workflow resolves one token per job through the [`setup-git-user`](#setup-git-user) action and uses it for every `gh` call, and for the checkout it pushes from, so the version bump and the thumbnail update are attributed to whichever identity was resolved.
 
-| Secret    | Description                                                                                                   |
-| --------- | ------------------------------------------------------------------------------------------------------------- |
-| `APP_KEY` | GitHub App private key. Required when `gh-app-id` is provided. Used to generate tokens for GitHub operations. |
+| Configuration                                      | Token                             | Identity                |
+| -------------------------------------------------- | --------------------------------- | ----------------------- |
+| `gh-app-id` (or the `APP_ID` variable) and `APP_KEY` | GitHub App installation token     | `<app-slug>[bot]`       |
+| `GH_TOKEN` secret                                  | The personal access token supplied | `github-actions[bot]`   |
+| Neither                                            | The default `GITHUB_TOKEN`        | `github-actions[bot]`   |
 
-Alternatively, if not using a GitHub App, the workflow falls back to the default `GITHUB_TOKEN`.
-A `GH_TOKEN` secret (personal access token) can also be provided as an override.
+Secrets reach the workflow through `secrets: inherit`.
+An App id supplied without `APP_KEY` emits a warning and falls back rather than failing, so a repository that inherits the `APP_ID` variable without the matching secret still releases.
+
+Two limitations apply to the `GITHUB_TOKEN` path only.
+
+- A push made with `GITHUB_TOKEN` triggers no workflow, so the version bump pull request receives no checks. Where the default branch requires status checks, `gh pr merge --auto` then never completes. Configure a GitHub App, or supply a `GH_TOKEN` personal access token.
+- Creating the version bump pull request needs the repository setting "Allow GitHub Actions to create and approve pull requests", under Settings, Actions, General. Without it `gh pr create` fails.
 
 #### Example
 
@@ -204,3 +211,35 @@ The detected formats and engines are written to the job summary by the action it
 [`test-setup-quarto-compute.yml`](.github/workflows/test-setup-quarto-compute.yml) runs the action against the fixtures under [`tests/`](tests), one per install path: `knitr` with a `renv.lock`, `jupyter` with and without a `pyproject.toml`, `julia`, a PDF format, and a Reveal.js deck converted with DeckTape as the release workflow does.
 Each fixture asserts what detection reported, checks that the toolchain it installed is usable, and renders.
 It runs on pull requests touching the action, its fixtures, or the slides script, on dispatch, and monthly.
+
+### [`setup-git-user`](.github/actions/setup-git-user/action.yml)
+
+A composite action that resolves the token the calling job commits, pushes, and calls `gh` with, and configures the matching git identity.
+It is used by `release.yml` and `quarto-extensions-updates.yml`.
+
+A GitHub App is used only when both `gh-app-id` and `app-key` are supplied, since [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) requires the private key.
+An id supplied without a key emits a warning and falls back, so a repository holding the `APP_ID` variable without the matching secret still runs.
+The action fails when it is given no credentials at all, rather than leaving every later `gh` call to fail on its own.
+
+Because a GitHub App token lasts an hour, a job that pushes long after it started resolves a fresh one first.
+The release workflow does this before updating the template thumbnail, which happens after the runtimes are installed and the project is rendered.
+
+#### Inputs
+
+| Input       | Default | Description                                                            |
+| ----------- | ------- | ------------------------------------------------------------------------ |
+| `gh-app-id` | `""`    | GitHub App client ID. A private key is required alongside it.          |
+| `app-key`   | `""`    | GitHub App private key.                                                |
+| `gh-token`  | `""`    | Token used when no GitHub App is available.                            |
+
+#### Outputs
+
+| Output  | Description                                                              |
+| ------- | -------------------------------------------------------------------------- |
+| `token` | The GitHub App installation token, or `gh-token` when there is no App.   |
+
+#### Tests
+
+[`test-setup-git-user.yml`](.github/workflows/test-setup-git-user.yml) runs the action once per credential path: no App, an App id without a key, a full App when the repository has one configured, and no credentials at all.
+Each asserts the identity written to the git configuration and that a token was resolved, and the last asserts that the action refused to run.
+It runs on pull requests touching the action, on dispatch, and monthly.

--- a/README.md
+++ b/README.md
@@ -241,5 +241,5 @@ The release workflow does this before updating the template thumbnail, which hap
 #### Tests
 
 [`test-setup-git-user.yml`](.github/workflows/test-setup-git-user.yml) runs the action once per credential path: no App, an App id without a key, a full App when the repository has one configured, and no credentials at all.
-Each asserts the identity written to the git configuration and that a token was resolved, and the last asserts that the action refused to run.
-It runs on pull requests touching the action, on dispatch, and monthly.
+Each asserts the identity written to the git configuration and that a token was resolved, through the shared [`assert-git-identity.sh`](.github/workflows/assets/assert-git-identity.sh), and the last asserts that the action refused to run.
+It runs on pull requests touching the action or that script, on dispatch, and monthly.


### PR DESCRIPTION
The `setup-git-user` action created a GitHub App token whenever an App id was supplied, without checking for the private key. `actions/create-github-app-token` requires that key, so a repository holding the `APP_ID` variable without the matching `APP_KEY` secret failed the job instead of falling back. The action now decides the path from both values, warns when only the id is present, and refuses to run only when it has no credentials at all. It also falls back when the App user id lookup comes back empty, rather than composing a malformed noreply address.

The release workflow resolved a token but never pushed with it. `actions/checkout` persisted the default `GITHUB_TOKEN`, so every push was made as `github-actions[bot]` whether or not an App was configured. A push made with `GITHUB_TOKEN` triggers no workflow, which left the version bump pull request without the checks its auto-merge waits for. `Setup Git User` now runs before the checkout in the three jobs that push and hands the checkout the resolved token. The App id is derived once in a workflow-level `env`, falling back to the `APP_ID` variable as it already did in `quarto-extensions-updates.yml`; the key and the fallback token stay at the call sites, since a workflow-level `env` cannot read `secrets`.

An App token expires after an hour, and the deploy job spends that hour installing runtimes and rendering before it updates the template thumbnail, so that push resolves a fresh token and replaces the credentials the checkout left behind.

`test-setup-git-user.yml` covers the four credential paths: no App, an App id without a key, a full App when the repository has one configured, and no credentials at all. The identity assertions share `assets/assert-git-identity.sh`, alongside the existing slides script. The README describes what each path resolves to, and the two limitations that apply to the `GITHUB_TOKEN` path.