### PR TITLE
fix: drop the release credentials before running project code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,8 +332,7 @@ jobs:
       - name: Drop the git credentials before running project code
         shell: bash
         run: |
-          # actions/checkout names the key after the server it cloned from, so
-          # the key is derived the same way rather than spelled out.
+          # The key actions/checkout derives from the server it cloned from.
           git config --local --unset-all "http.${GITHUB_SERVER_URL}/.extraheader" || true
 
           # An unset that matched nothing exits non-zero and would be swallowed
@@ -450,6 +449,10 @@ jobs:
           sparse-checkout: .github/workflows/assets/slides-to-pdf.sh
           sparse-checkout-cone-mode: false
           path: workflows
+          # Only the script is wanted, and it is read as a plain file rather
+          # than through git, so this checkout does not undo the credential
+          # drop above by persisting a token of its own beside the render.
+          persist-credentials: false
 
       - name: Exclude CHANGELOG.md from render
         env:
@@ -670,8 +673,9 @@ jobs:
         run: |
           if [ -f "${OUTPUT_DIRECTORY}/index.png" ]; then
             # The credentials the checkout left behind were dropped before the
-            # render, so this push carries the refreshed token instead.
-            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            # render, so this push carries the refreshed token instead. The host
+            # is derived rather than spelled out, as it is for the key above.
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}.git"
 
             mv -f "${OUTPUT_DIRECTORY}/index.png" .github/template.png
             if git show-ref --quiet "refs/heads/${BRANCH}"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,17 @@ jobs:
           git checkout "${GITHUB_REF_NAME}"
           git pull origin "${GITHUB_REF_NAME}"
 
+      # Everything below this point runs code the released project controls:
+      # dependency restores, executed chunks, and pre-render and post-render
+      # scripts. The credentials the checkout left in .git/config are not
+      # needed again until the thumbnail push, which resolves its own, and a
+      # GitHub App installation token reaches every repository the App is
+      # installed on rather than this one alone. So they go now.
+      - name: Drop the git credentials before running project code
+        shell: bash
+        run: |
+          git config --local --unset-all "http.https://github.com/.extraheader" || true
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
@@ -648,10 +659,8 @@ jobs:
         shell: bash
         run: |
           if [ -f "${OUTPUT_DIRECTORY}/index.png" ]; then
-            # actions/checkout left the token it was given in an http extraheader,
-            # which wins over anything in the remote URL, so the stale one has to
-            # go before the fresh one can be used.
-            git config --local --unset-all "http.https://github.com/.extraheader" || true
+            # The credentials the checkout left behind were dropped before the
+            # render, so this push carries the refreshed token instead.
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
             mv -f "${OUTPUT_DIRECTORY}/index.png" .github/template.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,7 +332,17 @@ jobs:
       - name: Drop the git credentials before running project code
         shell: bash
         run: |
-          git config --local --unset-all "http.https://github.com/.extraheader" || true
+          # actions/checkout names the key after the server it cloned from, so
+          # the key is derived the same way rather than spelled out.
+          git config --local --unset-all "http.${GITHUB_SERVER_URL}/.extraheader" || true
+
+          # An unset that matched nothing exits non-zero and would be swallowed
+          # above, leaving the render holding a token. Fail loudly instead.
+          if git config --local --name-only --get-regexp '^http\..*\.extraheader$'; then
+            echo "::error::Credentials are still present in .git/config."
+            exit 1
+          fi
+          echo "No credentials remain in .git/config."
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The workflow resolves one token per job through the [`setup-git-user`](#setup-gi
 Secrets reach the workflow through `secrets: inherit`.
 An App id supplied without `APP_KEY` emits a warning and falls back rather than failing, so a repository that inherits the `APP_ID` variable without the matching secret still releases.
 
+The release job drops the credentials the checkout left in `.git/config` once it has updated the branch, before it restores dependencies and renders, since everything from that point runs code the released project controls.
+A project that resolves a private GitHub dependency from `renv.lock`, `pyproject.toml`, or `Project.toml` therefore has to carry its own credentials for it rather than borrow the release token.
+
 Two limitations apply to the `GITHUB_TOKEN` path only.
 
 - A push made with `GITHUB_TOKEN` triggers no workflow, so the version bump pull request receives no checks. Where the default branch requires status checks, `gh pr merge --auto` then never completes. Configure a GitHub App, or supply a `GH_TOKEN` personal access token.


### PR DESCRIPTION
Follow-up to #36.

The deploy job kept the token `actions/checkout` persisted in `.git/config` for the whole job, including across `setup-quarto-compute`, which restores dependencies, and `quarto render`, which executes chunks and pre-render and post-render scripts. All of that is code the released project controls. Before #36 the token sitting there was the job-scoped `GITHUB_TOKEN`, bounded by the workflow `permissions:` block and dead at the end of the job; it is now a GitHub App installation token, which is valid for every repository the App is installed on. That widened the reach of a hostile package or render script from this one repository to the whole installation.

Nothing between the branch update and the thumbnail push needs those credentials. `setup-quarto-compute` makes no git or API call, and the thumbnail push already resolves a fresh token and points the remote at it, so the extra `--unset-all` it carried is now redundant and gone. The credentials are dropped as soon as `Update branch` has finished.

One behaviour change worth naming: a project that resolves a private GitHub dependency from `renv.lock`, `pyproject.toml`, or `Project.toml` can no longer borrow the release token for it and has to supply its own. That is the exposure being closed rather than an accident, and the README says so.

This path cannot be exercised without cutting a real release, so it is covered by `actionlint` and by reading only.