### PR TITLE
fix: fail the release when no check can ever arrive

### DIFF
--- a/.github/actions/setup-quarto-compute/action.yml
+++ b/.github/actions/setup-quarto-compute/action.yml
@@ -195,6 +195,10 @@ runs:
           echo "| Engines | \`${ENGINES}\` |"
         } >> "${GITHUB_STEP_SUMMARY}"
 
+        # The input paths come off the filesystem, where a newline is a legal
+        # character in a name, so a fixed marker is one crafted path away from
+        # ending the value early and having the rest parsed as further outputs.
+        INPUT_FILES_DELIM="INPUT_FILES_$(openssl rand -hex 16)"
         {
           echo "formats=${FORMATS}"
           echo "engines=${ENGINES}"
@@ -202,9 +206,9 @@ runs:
           echo "need-python=${NEED_PYTHON}"
           echo "need-julia=${NEED_JULIA}"
           echo "need-tinytex=${NEED_TINYTEX}"
-          echo "input-files<<INPUT_FILES_DELIM"
+          echo "input-files<<${INPUT_FILES_DELIM}"
           echo "${INPUT_FILES}"
-          echo "INPUT_FILES_DELIM"
+          echo "${INPUT_FILES_DELIM}"
         } >> "${GITHUB_OUTPUT}"
 
     # A documentation website lives under docs/ while the dependency manifests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ on:
         description: "GitHub App ID"
         required: false
         type: string
+      merge-timeout:
+        description: "Seconds to wait for the version bump pull request to merge"
+        required: false
+        default: 1800
+        type: number
 
 permissions:
   contents: write
@@ -67,10 +72,10 @@ jobs:
       BRANCH: ci/bump-version
       COMMIT: "ci: bump version for release :rocket:"
       BUMP_VERSION: ${{ inputs.version }}
-      # How long to wait for the bump pull request to merge. Auto-merge waits
-      # for whatever checks the default branch requires, so this has to cover a
-      # full check suite.
-      MERGE_TIMEOUT: "1800"
+      # Auto-merge waits for whatever checks the default branch requires, so a
+      # repository whose suite outlasts the default raises this rather than
+      # forking the workflow.
+      MERGE_TIMEOUT: ${{ inputs.merge-timeout }}
 
     outputs:
       version: ${{ steps.bump-version.outputs.version }}
@@ -321,15 +326,24 @@ jobs:
           # then install the wrong thing.
           MERGE_SHA=""
           DEADLINE=$(( SECONDS + MERGE_TIMEOUT ))
+          # Long enough that GitHub has created any check run it was going to.
+          BLOCKED_AFTER=$(( SECONDS + 120 ))
+          # Every field comes from one response: read separately they would
+          # answer about different instants. Joined on a character none of them
+          # can contain, since bash collapses runs of a whitespace separator and
+          # would shift an empty field into its neighbour.
+          POLL='[.state, (.mergeCommit.oid // ""), (.mergeStateStatus // ""), (.reviewDecision // ""), (.statusCheckRollup | length)] | map(tostring) | join("|")'
           while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
-            # Both fields come from one response: read separately, they answer
-            # about two different instants. The merge commit is not always
-            # attached the moment the state flips, so an empty one polls again
-            # rather than carrying the literal "null" forward.
-            INFO=$(gh pr view "${PR_URL}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | @tsv') || INFO=""
-            IFS=$'\t' read -r STATE MERGE_SHA <<< "${INFO}"
+            INFO=$(gh pr view "${PR_URL}" \
+              --json state,mergeCommit,mergeStateStatus,reviewDecision,statusCheckRollup \
+              --jq "${POLL}") || INFO=""
+            IFS='|' read -r STATE MERGE_SHA MERGE_STATE REVIEW CHECKS <<< "${INFO}"
+
             case "${STATE}" in
               MERGED)
+                # The merge commit is not always attached the moment the state
+                # flips, so an empty one polls again rather than carrying the
+                # literal "null" forward.
                 if [ -n "${MERGE_SHA}" ]; then
                   echo "Merged as ${MERGE_SHA}."
                   break
@@ -340,11 +354,27 @@ jobs:
                 exit 1
                 ;;
             esac
+
+            # A push made with the default GITHUB_TOKEN triggers no workflow, so
+            # where the branch requires status checks none are ever created and
+            # auto-merge waits for something that cannot arrive. Waiting out the
+            # timeout to say so costs the whole budget in billed runner time, so
+            # the pull request being blocked with no check of any kind against it
+            # is taken as the answer. A branch that also wants a review is left
+            # to the timeout: that block is a person, not a configuration.
+            if [ "${SECONDS}" -ge "${BLOCKED_AFTER}" ] &&
+              [ "${MERGE_STATE}" = "BLOCKED" ] &&
+              [ "${CHECKS}" = "0" ] &&
+              [ "${REVIEW}" != "REVIEW_REQUIRED" ]; then
+              echo "::error::${PR_URL} is blocked and nothing has reported a check against it. The default branch requires status checks and the push that opened the pull request triggered none: configure a GitHub App, or supply a GH_TOKEN personal access token."
+              exit 1
+            fi
+
             sleep 10
           done
 
           if [ -z "${MERGE_SHA}" ]; then
-            echo "::error::${PR_URL} did not merge within ${MERGE_TIMEOUT}s. Auto-merge waits for the branch's required checks, and a push made with the default GITHUB_TOKEN triggers none of them; configure a GitHub App or supply a GH_TOKEN personal access token."
+            echo "::error::${PR_URL} did not merge within ${MERGE_TIMEOUT}s. Raise the merge-timeout input if the branch's required checks simply take longer than that."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Both repo types record the release version and date in `CITATION.cff`, so the fi
 | `repo-type` | `"auto"`    | Repo type (`auto`/`extension`/`project`). `auto` detects from the repo name and owned manifest.     |
 | `quarto`    | `"release"` | Quarto version to install (`release` or `pre-release`).                                             |
 | `gh-app-id` |             | GitHub App ID for authentication (optional). Falls back to the `APP_ID` repository variable.        |
+| `merge-timeout` | `1800`  | Seconds to wait for the version bump pull request to merge.                                        |
 
 #### Authentication
 
@@ -54,7 +55,7 @@ A project that resolves a private GitHub dependency from `renv.lock`, `pyproject
 
 Two limitations apply to the `GITHUB_TOKEN` path only.
 
-- A push made with `GITHUB_TOKEN` triggers no workflow, so the version bump pull request receives no checks. Where the default branch requires status checks, `gh pr merge --auto` then never completes, and the release fails after waiting 30 minutes rather than tagging a commit that was never bumped. Configure a GitHub App, or supply a `GH_TOKEN` personal access token.
+- A push made with `GITHUB_TOKEN` triggers no workflow, so the version bump pull request receives no checks. Where the default branch requires status checks, `gh pr merge --auto` then never completes. The release fails rather than tagging a commit that was never bumped, and says so within a couple of minutes: a pull request that is blocked with no check of any kind reported against it is waiting for something that cannot arrive. Configure a GitHub App, or supply a `GH_TOKEN` personal access token. A branch that requires a review as well is left to `merge-timeout`, since that block is a person rather than a configuration.
 - Creating the version bump pull request needs the repository setting "Allow GitHub Actions to create and approve pull requests", under Settings, Actions, General. Without it `gh pr create` fails.
 
 #### Example


### PR DESCRIPTION
Three follow-ups left open by #38.

A push made with the default `GITHUB_TOKEN` triggers no workflow, so where the default branch requires status checks none are ever created and auto-merge waits for something that cannot arrive. The merge wait added in #38 reached that conclusion only by timing out, which spends the whole 30 minute budget in billed runner time, and the queueing concurrency group holds the next release behind it for the same 30 minutes.

The poll now treats a pull request that is blocked with no check of any kind reported against it as the answer, once past a two minute grace period long enough for GitHub to have created any check run it was going to. The signals all come from the `gh pr view` call the loop already makes, so this costs no extra API traffic and needs no admin scope, unlike reading branch protection. A branch that also requires a review is left to the timeout, since `BLOCKED` there means a person rather than a configuration, and so is a poll that could not read the pull request at all.

While rewriting that query: the fields are now joined on a character none of them can contain rather than a tab. Bash collapses runs of a whitespace separator, so an absent merge commit shifted every later field into its neighbour. The two-field version merged in #38 was unaffected, because its only empty field was the last one, but the five-field version would have been wrong on every poll before the merge landed.

`merge-timeout` becomes a `workflow_call` input. It was a job `env`, so a repository whose required checks outlast the default had no remedy but forking the workflow. Every other tunable here is already an input.

Separately, `setup-quarto-compute` writes its `input-files` output with a fixed heredoc marker, and those values are paths read off the filesystem, where a newline is a legal character in a name. A crafted path could end the value early and have the rest parsed as further step outputs. It now uses a random delimiter, as the release notes do.

The merge-wait loop was exercised against scripted API responses for all seven paths through it: the hopeless configuration fails fast; review-required, API-unavailable, and a transient blocked state within the grace period all correctly do not; checks-then-merge, a lagging merge commit, and a closed unmerged pull request behave as before. Verified with `actionlint` (shellcheck integration), `shellcheck`, and `markdownlint`.