### PR TITLE
fix: publish lightweight version tags

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -143,12 +143,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          git tag -a "${VERSION}" -m "${VERSION}"
+          # Lightweight, deliberately, and not to be turned back into annotated
+          # tags. `release.yml` calls the Pages workflow through a relative
+          # reference, and GitHub does not peel an annotated tag to its commit
+          # when it resolves one: a caller pinning an annotated tag fails the
+          # whole run before a single job starts, with no error beyond "this run
+          # likely failed because of a workflow file issue". Branches, commit
+          # SHAs, and lightweight tags all resolve. `tag.gpgSign` is spelled out
+          # because it would otherwise turn these into annotated tags wherever it
+          # is configured.
+          git -c tag.gpgSign=false tag "${VERSION}"
 
           # The rolling tags are what callers actually pin, so they are moved on
           # to this commit. Only the exact version is immutable.
-          git tag -f -a "${MINOR}" -m "${VERSION}"
-          git tag -f -a "${MAJOR}" -m "${VERSION}"
+          git -c tag.gpgSign=false tag -f "${MINOR}"
+          git -c tag.gpgSign=false tag -f "${MAJOR}"
 
           git push origin "${VERSION}"
           git push --force origin "${MINOR}" "${MAJOR}"


### PR DESCRIPTION
A canary pinned at `@v1` failed the whole run at startup, before any job began, reporting only that the run "likely failed because of a workflow file issue".

`release.yml` reaches the Pages workflow through a relative reference, which is the only form that can follow the ref a caller pinned, since `uses` accepts no expressions. GitHub does not peel an annotated tag to its commit when it resolves such a reference, so the nested call cannot be found and the run never starts.

Isolated by pinning the same caller four ways against the same commit:

| Ref used to call `release.yml` | Result |
| --- | --- |
| Branch | works |
| Commit SHA | works |
| Lightweight tag | works |
| Annotated tag | `startup_failure` |

`pages.yml@v1` runs fine throughout, since it contains no nested call. That is what made the earlier branch-pinned canaries pass and left this undetected.

`version.yml` now creates the three tags as lightweight. `tag.gpgSign` is overridden per command, because it silently promotes a lightweight tag to an annotated one wherever it is configured.

The `v1.0.0`, `v1.0`, and `v1` tags already published are annotated and need recreating before any repository can pin them.