### PR TITLE
feat!: skip draft pull requests and scope release permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,8 @@ name: Pages
 # serves from GitHub Pages once it has one: it takes the slot the rendered
 # example.qmd or template.qmd used to fill. The Release workflow calls this
 # after tagging, and it is dispatchable on its own. Pull requests render the
-# site as a check, from their own head, but never deploy.
+# site as a check, from their own head, but never deploy, and a draft renders
+# nothing at all.
 on:
   workflow_call:
     inputs:
@@ -55,6 +56,15 @@ jobs:
   build:
     name: Render site
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    # A draft pull request is not asking for a check yet, and this render
+    # installs whichever runtimes the site executes with. `github.event` is the
+    # caller's event, so a dispatch or a release call leaves `pull_request`
+    # null and the job runs. A caller triggered by `pull_request` has to list
+    # `ready_for_review` among its `types`, since the default set fires nothing
+    # when a pull request leaves draft.
+    if: ${{ github.event.pull_request.draft != true }}
 
     steps:
       - name: Checkout repository
@@ -144,6 +154,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
 
     permissions:

--- a/.github/workflows/quarto-extensions-updates.yml
+++ b/.github/workflows/quarto-extensions-updates.yml
@@ -40,6 +40,7 @@ concurrency:
 jobs:
   quarto-extensions-updates:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ on:
         default: 1800
         type: number
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
-  pages: write
+# Declared per job rather than once here, so the job that renders the released
+# project, which runs executed chunks and pre-render and post-render scripts the
+# project controls, holds a read-only token. Only bump-version, thumbnail, and
+# release write. A called workflow cannot exceed what the calling job granted,
+# so these narrow the caller's block rather than widen it.
 
 # A release bumps a version, pushes a branch, and creates a tag, so two of them
 # at once would race over all three. Queue rather than cancel: a cancelled
@@ -57,16 +57,23 @@ concurrency:
   group: quarto-workflows-release-${{ github.ref }}
   cancel-in-progress: false
 
-# Every job resolves its own token, and each has to be told the same App id, so
-# it is derived once here rather than in each of the four calls. The key and the
-# fallback token stay at the call sites, since a workflow-level `env` cannot
-# read `secrets`.
+# Every job that writes resolves its own token, and each has to be told the same
+# App id, so it is derived once here rather than in each of the three calls. The
+# key and the fallback token stay at the call sites, since a workflow-level `env`
+# cannot read `secrets`.
 env:
   APP_ID: ${{ inputs.gh-app-id || vars.APP_ID }}
 
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    # Above merge-timeout, which this job spends polling: raising one raises
+    # this.
+    timeout-minutes: 45
+
+    permissions:
+      contents: write
+      pull-requests: write
 
     env:
       BRANCH: ci/bump-version
@@ -440,6 +447,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     needs: bump-version
 
@@ -447,6 +455,15 @@ jobs:
     # `environment` conditionally, and claiming `github-pages` while deploying
     # nothing would record a deployment that never happened, so the deployment
     # itself lives in publish-pages (no docs/) or deploy-pages (docs/) below.
+    #
+    # Read-only on contents, since everything past the checkout runs code the
+    # released project controls. `pages: write` is what configure-pages needs to
+    # stage the site for publish-pages. The one write this job used to make, the
+    # template thumbnail, is now the thumbnail job below.
+    permissions:
+      contents: read
+      pages: write
+
     env:
       QUARTOVERSION: ${{ inputs.quarto }}
       REPO_TYPE: ${{ needs.bump-version.outputs.repo_type }}
@@ -454,44 +471,23 @@ jobs:
 
     outputs:
       summary: ${{ steps.deployment-summary.outputs.summary }}
+      has_thumbnail: ${{ steps.stage-thumbnail.outputs.has_thumbnail }}
 
     steps:
-      # As in bump-version: the workflow's own actions, read from the commit the
-      # caller pinned. The repository checkout below clears this one, so it is
-      # taken again once that has happened.
-      - name: Checkout the workflow source
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ job.workflow_repository }}
-          ref: ${{ job.workflow_sha }}
-          path: .quarto-workflows
-          sparse-checkout: .github/actions
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-
-      - name: Setup Git User
-        uses: ./.quarto-workflows/.github/actions/setup-git-user
-        id: setup-git-user
-        with:
-          gh-app-id: ${{ env.APP_ID }}
-          app-key: ${{ secrets.APP_KEY }}
-          gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-
       # The commit the bump merged as, rather than whatever the default branch
       # points at by now: a commit landing in between would otherwise be
       # rendered and released without ever having been part of the release.
+      # The default token is enough to read the repository, and this job never
+      # writes, so no App token is resolved here at all.
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          token: ${{ steps.setup-git-user.outputs.token }}
           ref: ${{ needs.bump-version.outputs.merge_sha }}
 
       # Everything below this point runs code the released project controls:
       # dependency restores, executed chunks, and pre-render and post-render
       # scripts. The credentials the checkout left in .git/config are not
-      # needed again until the thumbnail push, which resolves its own, and a
-      # GitHub App installation token reaches every repository the App is
-      # installed on rather than this one alone. So they go now.
+      # needed again by this job at all, so they go now.
       - name: Drop the git credentials before running project code
         shell: bash
         run: |
@@ -506,9 +502,13 @@ jobs:
           fi
           echo "No credentials remain in .git/config."
 
-      # Restored after the repository checkout cleared it, and widened to the
-      # assets, since the slide conversion below reads a script from them. The
-      # name is dot-prefixed so that Quarto leaves it out of the render.
+      # The workflow's own actions and assets, read from the commit the caller
+      # pinned rather than from a branch that moves under it. A local `uses: ./`
+      # is resolved against the workspace, which is why they are checked out
+      # into it, after the repository checkout that would otherwise clear them.
+      # The assets are included because the slide conversion below reads a
+      # script from them. The name is dot-prefixed so that Quarto leaves it out
+      # of the render.
       - name: Checkout the workflow source
         uses: actions/checkout@v7
         with:
@@ -793,90 +793,34 @@ jobs:
           path: |
             ${{ steps.render-quarto.outputs.asset_paths }}
 
-      # The render between here and the earlier checkout ran project code, which
-      # is free to write anywhere in the workspace. The action that is about to
-      # be handed APP_KEY is therefore taken from the pinned commit again rather
-      # than read off disk. A runner enforces no boundary here either way, so
-      # this is hygiene rather than containment.
-      - name: Restore the workflow source
+      # The rendered thumbnail is handed to the thumbnail job rather than pushed
+      # from here, so that this job, which has just run the released project's
+      # own code, needs no write of any kind. Staged under a directory of its
+      # own, since the artifact is downloaded straight over .github/ there.
+      - name: Stage the template thumbnail
+        id: stage-thumbnail
         if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ job.workflow_repository }}
-          ref: ${{ job.workflow_sha }}
-          path: .quarto-workflows
-          sparse-checkout: .github/actions
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-
-      # A GitHub App token lasts an hour, and this job spends that hour
-      # installing runtimes and rendering before it pushes anything, so the one
-      # the checkout is holding may well have expired by now.
-      - name: Refresh the token before pushing
-        id: refresh-git-user
-        if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
-        uses: ./.quarto-workflows/.github/actions/setup-git-user
-        with:
-          gh-app-id: ${{ env.APP_ID }}
-          app-key: ${{ secrets.APP_KEY }}
-          gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-
-      # The thumbnail is not part of the release being cut, so a failure here
-      # reports itself and lets the tag, the release, and the deployment go out.
-      - name: Update template thumbnail
-        if: ${{ steps.render-quarto.outputs.slides_assets_exists == 'true' }}
-        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.refresh-git-user.outputs.token }}
           OUTPUT_DIRECTORY: ${{ steps.detect-project-dir.outputs.output_directory }}
-          BRANCH: ci/update-thumbs
-          COMMIT: "ci: update thumbs :art:"
         shell: bash
         run: |
           if [ -f "${OUTPUT_DIRECTORY}/index.png" ]; then
-            # The credentials the checkout left behind were dropped before the
-            # render, so this push carries the refreshed token instead. The host
-            # is derived rather than spelled out, as it is for the key above.
-            git remote set-url origin "https://x-access-token:${GH_TOKEN}@${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}.git"
-
-            mv -f "${OUTPUT_DIRECTORY}/index.png" .github/template.png
-            # As for the bump branch: the branch only ever exists on the remote,
-            # and a pull request left open by an earlier run would make
-            # `gh pr create` below fail.
-            if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
-              echo "Remote branch ${BRANCH} already exists; it will be force-pushed."
-              STALE_PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
-              if [ -n "${STALE_PR}" ]; then
-                echo "Closing the stale pull request #${STALE_PR}."
-                gh pr close "${STALE_PR}"
-              fi
-            fi
-            git checkout -B "${BRANCH}"
-            git add .github/template.png || echo "No changes to add"
-            if ! git diff --cached --quiet; then
-              git commit -m "${COMMIT}"
-              git push --force origin "${BRANCH}"
-              # Spelled out rather than filled from the branch's first commit:
-              # `--fill-first` reads `origin/<base>...<head>`, and this job
-              # checks out the merge commit by SHA, which leaves no
-              # remote-tracking ref for the base to resolve against. The title
-              # is the commit message either way.
-              PR_URL=$(gh pr create \
-                --title "${COMMIT}" \
-                --body "Regenerated \`.github/template.png\` from the rendered slides." \
-                --base "${GITHUB_REF_NAME}" \
-                --head "${BRANCH}" \
-                --label "Type: CI/CD :robot:" | tail -n 1)
-              echo "Pull request: ${PR_URL}"
-              sleep 5
-              # Named rather than inferred from the checked-out branch, as the
-              # bump job does.
-              gh pr merge "${PR_URL}" --auto --squash --delete-branch
-              sleep 5
-            else
-              echo "No changes to commit."
-            fi
+            mkdir -p .template-thumbnail
+            mv -f "${OUTPUT_DIRECTORY}/index.png" .template-thumbnail/template.png
+            HAS_THUMBNAIL=true
+          else
+            HAS_THUMBNAIL=false
+            echo "No ${OUTPUT_DIRECTORY}/index.png; nothing to stage."
           fi
+          echo "has_thumbnail=${HAS_THUMBNAIL}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload the template thumbnail
+        if: ${{ steps.stage-thumbnail.outputs.has_thumbnail == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: template-thumbnail
+          path: .template-thumbnail/template.png
+          retention-days: 1
 
       # Formats and engines are reported by the compute action itself, in this
       # job's own summary, so they are not repeated here.
@@ -895,11 +839,132 @@ jobs:
           fi
           echo "summary=${SUMMARY}" >> "${GITHUB_OUTPUT}"
 
+  # The thumbnail a deck renders is committed back, which is the one write the
+  # render used to make while holding the released project's code. It sits in a
+  # job of its own so that render stays read-only, and so the token it pushes
+  # with is resolved here, minutes rather than an hour after the release
+  # started: a GitHub App installation token lasts an hour, and installing
+  # runtimes and rendering can spend most of one.
+  #
+  # The thumbnail is not part of the release being cut, so a failure here
+  # reports itself and lets the tag, the release, and the deployment go out.
+  # Nothing depends on this job for the same reason.
+  thumbnail:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    needs:
+      - bump-version
+      - deploy
+
+    if: ${{ needs.deploy.outputs.has_thumbnail == 'true' }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      BRANCH: ci/update-thumbs
+      COMMIT: "ci: update thumbs :art:"
+
+    steps:
+      # As in bump-version: the workflow's own actions, read from the commit the
+      # caller pinned, and cleared by the repository checkout below.
+      - name: Checkout the workflow source
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .quarto-workflows
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Setup Git User
+        uses: ./.quarto-workflows/.github/actions/setup-git-user
+        id: setup-git-user
+        with:
+          gh-app-id: ${{ env.APP_ID }}
+          app-key: ${{ secrets.APP_KEY }}
+          gh-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      # The commit the release was cut from, as in the deploy and release jobs,
+      # so the thumbnail branch forks from the released tree rather than from
+      # whatever the default branch points at by now.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.setup-git-user.outputs.token }}
+          ref: ${{ needs.bump-version.outputs.merge_sha }}
+
+      # As in bump-version: the runner resolves an action's post step from disk
+      # when the job ends, so the source the checkout above cleared has to be
+      # back by then or the job fails after all its work is done.
+      - name: Restore the workflow source
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .quarto-workflows
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download the template thumbnail
+        uses: actions/download-artifact@v8
+        with:
+          name: template-thumbnail
+          path: .github
+
+      - name: Open the thumbnail pull request
+        env:
+          GH_TOKEN: ${{ steps.setup-git-user.outputs.token }}
+        shell: bash
+        run: |
+          # As for the bump branch: the branch only ever exists on the remote,
+          # and a pull request left open by an earlier run would make
+          # `gh pr create` below fail.
+          if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
+            echo "Remote branch ${BRANCH} already exists; it will be force-pushed."
+            STALE_PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+            if [ -n "${STALE_PR}" ]; then
+              echo "Closing the stale pull request #${STALE_PR}."
+              gh pr close "${STALE_PR}"
+            fi
+          fi
+          git checkout -B "${BRANCH}"
+          git add .github/template.png || echo "No changes to add"
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "${COMMIT}"
+          git push --force origin "${BRANCH}"
+          # Spelled out rather than filled from the branch's first commit:
+          # `--fill-first` reads `origin/<base>...<head>`, and this job checks
+          # out the merge commit by SHA, which leaves no remote-tracking ref for
+          # the base to resolve against. The title is the commit message either
+          # way.
+          PR_URL=$(gh pr create \
+            --title "${COMMIT}" \
+            --body "Regenerated \`.github/template.png\` from the rendered slides." \
+            --base "${GITHUB_REF_NAME}" \
+            --head "${BRANCH}" \
+            --label "Type: CI/CD :robot:" | tail -n 1)
+          echo "Pull request: ${PR_URL}"
+          sleep 5
+          # Named rather than inferred from the checked-out branch, as the bump
+          # job does.
+          gh pr merge "${PR_URL}" --auto --squash --delete-branch
+
   # A repository without docs/ publishes its rendered example or template to
   # Pages, as it always has. The deployment sits in its own job so the
   # github-pages environment is claimed only when something is deployed.
   publish-pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     needs:
       - bump-version
@@ -936,10 +1001,15 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     needs:
       - bump-version
       - deploy
+
+    # The tag and the release itself.
+    permissions:
+      contents: write
 
     steps:
       # As in bump-version, cleared in the same way by the checkout below, and

--- a/.github/workflows/test-setup-git-user.yml
+++ b/.github/workflows/test-setup-git-user.yml
@@ -9,6 +9,9 @@ name: Test Setup Git User
 # of a GitHub App is available. Each of those paths is exercised here.
 on:
   pull_request:
+    # As in the compute test: a draft skips every job below, and the default
+    # activity types fire nothing when a pull request leaves draft.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/actions/setup-git-user/**"
       - ".github/workflows/test-setup-git-user.yml"
@@ -30,6 +33,9 @@ jobs:
   check-app:
     name: Check for App credentials
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    if: ${{ github.event.pull_request.draft != true }}
 
     outputs:
       has-app: ${{ steps.check.outputs.has-app }}
@@ -53,6 +59,9 @@ jobs:
   fallback:
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    if: ${{ github.event.pull_request.draft != true }}
 
     strategy:
       fail-fast: false
@@ -86,9 +95,10 @@ jobs:
   app:
     name: App credentials
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     needs: check-app
-    if: ${{ needs.check-app.outputs.has-app == 'true' }}
+    if: ${{ github.event.pull_request.draft != true && needs.check-app.outputs.has-app == 'true' }}
 
     steps:
       - name: Checkout repository
@@ -111,6 +121,9 @@ jobs:
   no-credentials:
     name: No credentials at all
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    if: ${{ github.event.pull_request.draft != true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-setup-quarto-compute.yml
+++ b/.github/workflows/test-setup-quarto-compute.yml
@@ -9,6 +9,10 @@ name: Test Setup Quarto Compute
 # fixture under tests/ exercises one of those paths here instead.
 on:
   pull_request:
+    # A draft pull request skips every job below, and the default activity types
+    # fire nothing when one leaves draft, so the render would then wait for a
+    # further push.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/actions/setup-quarto-compute/**"
       - ".github/workflows/test-setup-quarto-compute.yml"
@@ -29,6 +33,11 @@ jobs:
   detect:
     name: ${{ matrix.label || matrix.fixture }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    # Each fixture installs a language runtime and renders, which a draft pull
+    # request is not asking for yet.
+    if: ${{ github.event.pull_request.draft != true }}
 
     # Set for the job rather than for the compute step, so it reaches the steps
     # the composite action runs. Every fixture but one leaves it empty, and
@@ -205,6 +214,9 @@ jobs:
   slides:
     name: decktape
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    if: ${{ github.event.pull_request.draft != true }}
 
     # Mirrors what the release workflow does with a deck, so the browser
     # decktape drives is exercised here rather than during a release.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Refuse to tag anything but the default branch

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ GitHub Actions workflows for Quarto projects.
 Callers pin a tag rather than a branch.
 Three tags are published for every release: `vX.Y.Z`, which never moves, and `vX.Y` and `vX`, which roll forward on to each new release they cover.
 The examples below pin `vX`, which is the usual choice, since Dependabot's `github-actions` ecosystem updates a `uses:` reference to the next major on its own.
+The current major is `v2`.
 
 A change to a workflow input, or to what a workflow does to the repository calling it, bumps the major.
 Everything else is a minor or a patch.
@@ -35,6 +36,7 @@ Key features include:
 - **Slide-to-PDF conversion**: Automatic PDF generation using DeckTape for custom Reveal.js format extensions and presentations.
 - **GitHub integration**: Creates PRs for version bumps, deploys to GitHub Pages, and publishes releases with assets and install instructions.
 - **Bump before render**: The workflow waits for the version bump pull request to merge, then renders and tags the exact commit it merged as, so the tag always carries the bumped manifest.
+- **Read-only render**: The job that renders the released project holds no write scope, and the template thumbnail it produces is committed back by a separate job.
 
 Both repo types record the release version and date in `CITATION.cff`, so the file is required.
 
@@ -51,7 +53,7 @@ Both repo types record the release version and date in `CITATION.cff`, so the fi
 #### Authentication
 
 A GitHub App is optional.
-The workflow resolves one token per job through the [`setup-git-user`](#setup-git-user) action and uses it for every `gh` call, and for the checkout it pushes from, so the version bump and the thumbnail update are attributed to whichever identity was resolved.
+Each job that writes resolves its own token through the [`setup-git-user`](#setup-git-user) action and uses it for every `gh` call, and for the checkout it pushes from, so the version bump, the thumbnail update, and the release are attributed to whichever identity was resolved.
 
 | Configuration                                        | Token                              | Identity              |
 | ---------------------------------------------------- | ---------------------------------- | --------------------- |
@@ -62,8 +64,23 @@ The workflow resolves one token per job through the [`setup-git-user`](#setup-gi
 Secrets reach the workflow through `secrets: inherit`.
 An App id supplied without `APP_KEY` emits a warning and falls back rather than failing, so a repository that inherits the `APP_ID` variable without the matching secret still releases.
 
-The release job drops the credentials the checkout left in `.git/config` once it has updated the branch, before it restores dependencies and renders, since everything from that point runs code the released project controls.
+Scopes are declared per job rather than once for the workflow, so only the three jobs that write hold a token that can.
+
+| Job             | Permissions                                         | What it writes                                   |
+| --------------- | --------------------------------------------------- | ------------------------------------------------ |
+| `bump-version`  | `contents: write`, `pull-requests: write`           | The version bump branch and its pull request.    |
+| `deploy`        | `contents: read`, `pages: write`                    | Nothing; it renders, packages, and stages Pages. |
+| `thumbnail`     | `contents: write`, `pull-requests: write`           | `.github/template.png`, through a pull request.  |
+| `publish-pages` | `contents: read`, `pages: write`, `id-token: write` | The Pages deployment, where there is no `docs/`. |
+| `release`       | `contents: write`                                   | The tag and the GitHub release.                  |
+| `deploy-pages`  | `contents: read`, `pages: write`, `id-token: write` | The Pages deployment, where there is a `docs/`.  |
+
+The calling job still grants the union of these, since a called workflow can only narrow what it was given.
+
+The render job takes no App token at all, and drops the credentials the checkout left in `.git/config` before it restores dependencies and renders, since everything from that point runs code the released project controls.
 A project that resolves a private GitHub dependency from `renv.lock`, `pyproject.toml`, or `Project.toml` therefore has to carry its own credentials for it rather than borrow the release token.
+The template thumbnail a deck renders is handed to the `thumbnail` job as an artifact, which resolves its own token and opens the pull request.
+That job is allowed to fail: the tag, the release, and the deployment do not wait on it.
 
 Two limitations apply to the `GITHUB_TOKEN` path only.
 
@@ -102,7 +119,7 @@ permissions:
 
 jobs:
   release:
-    uses: mcanouil/quarto-workflows/.github/workflows/release.yml@v1
+    uses: mcanouil/quarto-workflows/.github/workflows/release.yml@v2
     permissions:
       contents: write
       pull-requests: write
@@ -124,9 +141,14 @@ A reusable workflow that renders the documentation website under `docs/` and dep
 The Release workflow calls it after tagging, so the published site describes the version users can install.
 It is also dispatchable on its own, and a pull request that calls it renders the site as a check without deploying.
 
+A draft pull request renders nothing.
+The render is what installs R, Python, Julia, TinyTeX, and the Chrome libraries the site needs, and a draft is not asking for that yet.
+A caller triggered by `pull_request` therefore has to list `ready_for_review` among its `types`, since the default set of `opened`, `synchronize`, and `reopened` fires nothing when a pull request leaves draft, and the render would otherwise wait for a further push.
+
 Key features include:
 
 - **Released source by default**: The latest version tag is resolved and rendered, unless `ref` or `use-main-as-release` says otherwise. Pull requests always render their own head.
+- **Drafts skipped**: A draft pull request skips the render, and marking it ready for review runs it.
 - **Extension mirror**: `docs/_scripts/sync-extension.sh` is run when present, so a shortcode contributed by the repository's own extension is on disk before Quarto builds its extension registry.
 - **Compute environment**: R, Python, Julia, TinyTeX, and Chrome libraries are installed from what [`setup-quarto-compute`](#setup-quarto-compute) detects, so pages that execute code render.
 - **Single deployment at a time**: Pages runs queue rather than cancel; pull request renders get a per-ref concurrency group and run in parallel.
@@ -146,6 +168,9 @@ name: Pages
 
 on:
   pull_request:
+    # The render is skipped while the pull request is a draft, and
+    # `ready_for_review` is what runs it once the draft is lifted.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "docs/**"
       - "_extensions/**"
@@ -170,7 +195,7 @@ permissions:
 
 jobs:
   pages:
-    uses: mcanouil/quarto-workflows/.github/workflows/pages.yml@v1
+    uses: mcanouil/quarto-workflows/.github/workflows/pages.yml@v2
     permissions:
       contents: read
       pages: write
@@ -213,7 +238,7 @@ permissions:
 
 jobs:
   update:
-    uses: mcanouil/quarto-workflows/.github/workflows/quarto-extensions-updates.yml@v1
+    uses: mcanouil/quarto-workflows/.github/workflows/quarto-extensions-updates.yml@v2
     permissions:
       contents: write
       pull-requests: write
@@ -278,7 +303,7 @@ The detected formats and engines are written to the job summary by the action it
 
 [`test-setup-quarto-compute.yml`](.github/workflows/test-setup-quarto-compute.yml) runs the action against the fixtures under [`tests/`](tests), one per install path: `knitr` with a `renv.lock`, `jupyter` with and without a `pyproject.toml`, `julia`, a PDF format, and a Reveal.js deck converted with DeckTape as the release workflow does.
 Each fixture asserts what detection reported, checks that the toolchain it installed is usable, and renders.
-It runs on pull requests touching the action, its fixtures, or the slides script, on dispatch, and monthly.
+It runs on pull requests touching the action, its fixtures, or the slides script, on dispatch, and monthly, and skips a pull request that is still a draft.
 
 ### [`setup-git-user`](.github/actions/setup-git-user/action.yml)
 
@@ -289,8 +314,8 @@ A GitHub App is used only when both `gh-app-id` and `app-key` are supplied, sinc
 An id supplied without a key emits a warning and falls back, so a repository holding the `APP_ID` variable without the matching secret still runs.
 The action fails when it is given no credentials at all, rather than leaving every later `gh` call to fail on its own.
 
-Because a GitHub App token lasts an hour, a job that pushes long after it started resolves a fresh one first.
-The release workflow does this before updating the template thumbnail, which happens after the runtimes are installed and the project is rendered.
+Because a GitHub App token lasts an hour, a job that pushes long after it started would find its token expired.
+The release workflow keeps every push in a job that resolves a token and then uses it: the template thumbnail is pushed by a job of its own rather than by the render that produced it, which can spend most of that hour installing runtimes.
 
 #### Inputs
 
@@ -310,4 +335,4 @@ The release workflow does this before updating the template thumbnail, which hap
 
 [`test-setup-git-user.yml`](.github/workflows/test-setup-git-user.yml) runs the action once per credential path: no App, an App id without a key, a full App when the repository has one configured, and no credentials at all.
 Each asserts the identity written to the git configuration and that a token was resolved, through the shared [`assert-git-identity.sh`](.github/workflows/assets/assert-git-identity.sh), and the last asserts that the action refused to run.
-It runs on pull requests touching the action or that script, on dispatch, and monthly.
+It runs on pull requests touching the action or that script, on dispatch, and monthly, and skips a pull request that is still a draft.


### PR DESCRIPTION
The Pages workflow rendered the documentation website for every pull request a caller forwarded, drafts included, and that render installs whichever of R, Python, Julia, TinyTeX, and Chrome the site needs. Its build job now skips a draft. A caller triggered by `pull_request` has to list `ready_for_review` among its types, since the default set of `opened`, `synchronize`, and `reopened` fires nothing when a draft is lifted. That requirement on callers is what makes this a major, so the README examples now pin `v2`.

The Release workflow granted `contents: write` and `pull-requests: write` to every job, including the one that renders the released project and so runs its executed chunks and its pre-render and post-render scripts. Scopes are declared per job instead. The one write that job made, the template thumbnail, moves to a job of its own that receives the image as an artifact, so the render needs nothing beyond reading the repository, and the thumbnail push resolves a fresh token rather than an installation token that may have expired while runtimes were installing. Nothing depends on that job, and it is allowed to fail, as the step it replaces was.

The two test workflows skip a draft in the same way, and every job in the repository now sets `timeout-minutes`, so a hung render or a stalled `tlmgr` cannot bill the six hour default.

Opening this as a draft is the check: every job on both test workflows should report skipped until it is marked ready for review.